### PR TITLE
Removed gitcode in favor of uri-based remote_code

### DIFF
--- a/lib/gollum-lib/remote_code.rb
+++ b/lib/gollum-lib/remote_code.rb
@@ -1,0 +1,39 @@
+# ~*~ encoding: utf-8 ~*~
+require 'net/http'
+require 'net/https' # ruby 1.8.7 fix, remove at upgrade
+require 'uri'
+require 'open-uri'
+
+module Gollum
+  class RemoteCode
+    def initialize path
+      raise(ArgumentError, 'path is nil or empty') if path.nil? or path.empty?
+      @uri = URI(path)
+    end
+
+    def contents
+      @contents ||= req @uri
+    end
+
+    private
+
+      def req uri, cut = 1
+        return "Too many redirects or retries" if cut >= 10
+        http = Net::HTTP.new uri.host, uri.port
+        http.use_ssl = true
+        resp = http.get uri.path, {
+          'Accept'        => 'text/plain',
+          'Cache-Control' => 'no-cache',
+          'Connection'    => 'keep-alive',
+          'User-Agent'    => 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:15.0) Gecko/20100101 Firefox/15.0'
+        }
+        code = resp.code.to_i
+        return resp.body if code == 200
+        return "Not Found" if code == 404
+        return "Unhandled Response Code #{code}" unless code == 304 or not resp.header['location'].nil?
+        loc = URI.parse resp.header['location']
+        uri2 = loc.relative? ? (uri + loc) : loc # overloads (+)
+        req uri2, (cut + 1)
+      end
+  end
+end

--- a/test/test_remote_code.rb
+++ b/test/test_remote_code.rb
@@ -2,7 +2,7 @@
 require File.expand_path( '../helper', __FILE__ )
 require File.expand_path( '../wiki_factory', __FILE__ )
 
-context "gitcode" do
+context "remote_code" do
 
   def page_with_content c
     index = @wiki.repo.index
@@ -20,7 +20,7 @@ context "gitcode" do
 
   test 'that the rendered output is correctly fetched and rendered as html code' do
     # given
-    p = page_with_content "a\n\n```html:github:gollum/gollum-lib/master/test/file_view/1_file.txt```\n\nb"
+    p = page_with_content "a\n\n```html:https://raw.github.com/gollum/gollum-lib/master/test/file_view/1_file.txt```\n\nb"
 
     # when rendering the page
     rendered = Gollum::Markup.new(p).render
@@ -31,13 +31,13 @@ context "gitcode" do
   end
 
   test 'contents' do
-    g = Gollum::Gitcode.new 'gollum/gollum-lib/master/test/file_view/1_file.txt'
+    g = Gollum::RemoteCode.new 'https://raw.github.com/gollum/gollum-lib/master/test/file_view/1_file.txt'
 
     expected = %{<ol class=\"tree\">\n  <li class=\"file\">\n    <a href=\"0\"><span class=\"icon\"></span>0</a>\n  </li>\n</ol>\n}
     assert_equal expected, g.contents
   end
 
-  test "gitcode relative local file" do
+  test "remote_code relative local file" do
     @wiki.write_page("Bilbo Baggins", :markdown, "a\n```python:file-exists.py```\nb", commit_details)
     page = @wiki.page('Bilbo Baggins')
 
@@ -51,7 +51,7 @@ context "gitcode" do
     assert_equal %Q{<p>a\n</p><div class="highlight"><pre><span class="kn">import</span> <span class="nn">sys</span>\n\n<span class="k">print</span> <span class="n">sys</span><span class="o">.</span><span class="n">maxint</span>\n</pre></div>\n\n<p>b</p>}, output
   end
 
-  test "gitcode relative local file in subdir" do
+  test "remote_code relative local file in subdir" do
     index = @wiki.repo.index
     index.add("foo/file-exists.py", "import sys\n\nprint sys.maxint\n")
     index.commit("Add file-exists.py")
@@ -63,14 +63,14 @@ context "gitcode" do
     assert_equal %Q{<p>a\n</p><div class="highlight"><pre><span class="kn">import</span> <span class="nn">sys</span>\n\n<span class="k">print</span> <span class="n">sys</span><span class="o">.</span><span class="n">maxint</span>\n</pre></div>\n\n<p>b</p>}, output
   end
 
-  test "gitcode relative no file" do
+  test "remote_code relative no file" do
     @wiki.write_page("Bilbo Baggins", :markdown, "a\n```python:no-file-exists.py```\nb", commit_details)
     page = @wiki.page('Bilbo Baggins')
     output = page.formatted_data
     assert_equal %Q{<p>a\nFile not found: no-file-exists.py\nb</p>}, output
   end
 
-  test "gitcode absolute local file" do
+  test "remote_code absolute local file" do
     @wiki.write_page("Bilbo Baggins", :markdown, "a\n```python:/monkey/file-exists.py```\nb", commit_details)
     page = @wiki.page('Bilbo Baggins')
 
@@ -83,14 +83,14 @@ context "gitcode" do
     assert_equal %Q{<p>a\n</p><div class="highlight"><pre><span class="kn">import</span> <span class="nn">sys</span>\n\n<span class="k">print</span> <span class="n">sys</span><span class="o">.</span><span class="n">platform</span>\n</pre></div>\n\n<p>b</p>}, output
   end
 
-  test "gitcode absolute no file" do
+  test "remote_code absolute no file" do
     @wiki.write_page("Bilbo Baggins", :markdown, "a\n```python:/monkey/no-file-exists.py```\nb", commit_details)
     page = @wiki.page('Bilbo Baggins')
     output = page.formatted_data
     assert_equal %Q{<p>a\nFile not found: /monkey/no-file-exists.py\nb</p>}, output
   end
 
-  test "gitcode error generates santized html" do
+  test "remote_code error generates santized html" do
     @wiki.write_page("Bilbo Baggins", :markdown, "a\n```python:<script>foo</script>```\nb", commit_details)
     page = @wiki.page('Bilbo Baggins')
     output = page.formatted_data


### PR DESCRIPTION
See gollum/gollum#663

@bootstraponline @simonista Do you think the `github:` pseudo-urls functionality should be kept in?
