### PR TITLE
Gollum::VERSION collision

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -30,8 +30,8 @@ def bump_version
   old_file = File.read("lib/#{name}.rb")
   old_version_line = old_file[/^\s*VERSION\s*=\s*.*/]
   new_version = next_version
-  # replace first match of old vesion with new version
-  old_file.sub!(old_version_line, "  VERSION = '#{new_version}'")
+  # replace first match of old version with new version
+  old_file.sub!(old_version_line, "    VERSION = '#{new_version}'")
 
   File.write("lib/#{name}.rb", old_file)
 

--- a/lib/gollum-lib.rb
+++ b/lib/gollum-lib.rb
@@ -29,7 +29,9 @@ require File.expand_path('../gollum-lib/web_sequence_diagram', __FILE__)
 $KCODE = 'U' if RUBY_VERSION[0,3] == '1.8'
 
 module Gollum
-  VERSION = '1.0.0'
+  module Lib
+    VERSION = '1.0.0'
+  end
 
   def self.assets_path
     ::File.expand_path('gollum/frontend/public', ::File.dirname(__FILE__))


### PR DESCRIPTION
`Gollum::VERSION` is currently defined in both gollum and gollum-lib and produces a warning when both libraries are loaded.

What is the best approach to avoid the collision?
- `Gollum::Lib::VERSION`
- `GollumLib::VERSION`
- other ?
