### PR TITLE
Update working directory properly when the page is within a subdirectory...

### DIFF
--- a/lib/gollum-lib/committer.rb
+++ b/lib/gollum-lib/committer.rb
@@ -134,7 +134,7 @@ module Gollum
     def update_working_dir(dir, name, format)
       unless @wiki.repo.bare
         if @wiki.page_file_dir
-          dir = dir.size.zero? ? @wiki.page_file_dir : ::File.join(dir, @wiki.page_file_dir)
+          dir = dir.size.zero? ? @wiki.page_file_dir : ::File.join(@wiki.page_file_dir, dir)
         end
 
         path =

--- a/test/test_committer.rb
+++ b/test/test_committer.rb
@@ -61,4 +61,20 @@ context "Wiki" do
     committer = Gollum::Committer.new(@wiki)
     assert_equal ref,  committer.parents.first.sha
   end
+
+
+  test "update working directory with page file directory and subdirectory" do
+    page_file_dir = "foo"
+    dir = "/bar"
+    name = "baz"
+    format = :markdown
+    @wiki = Gollum::Wiki.new(testpath("examples/lotr.git"), {:page_file_dir => page_file_dir})
+
+    @wiki.repo.stubs(:bare).returns(false)
+    Gollum::Committer.any_instance.stubs(:add_to_index).returns(true)
+    Grit::Index.any_instance.stubs(:commit).returns(true)
+
+    @wiki.repo.git.expects(:checkout).with(anything, anything, anything, "#{page_file_dir}#{dir}/#{name}.md")
+    @wiki.write_page(name, format, "foo bar baz", commit_details, dir)
+  end
 end


### PR DESCRIPTION
Update working directory properly when the page is within a subdirectory and the wiki is configured with a page file directory.

The checkout within the update working directory is receiving a jumbled file path and not actually issuing a checkout on the newly created file. The correct checkout is necessary to prevent a jumbled commit and a and a staged delete commit on a newly created page.
