### PR TITLE
Fix bug when renaming a page to a subdirectory containing spaces

### DIFF
--- a/lib/gollum-lib/page.rb
+++ b/lib/gollum-lib/page.rb
@@ -390,16 +390,15 @@ module Gollum
     # Returns a Gollum::Page or nil if the page could not be found.
     def find_page_in_tree(map, name, checked_dir = nil, exact = false)
       return nil if !map || name.to_s.empty?
-      if checked_dir = BlobEntry.normalize_dir(checked_dir)
-        checked_dir.downcase!
-      end
 
+      checked_dir = BlobEntry.normalize_dir(checked_dir)
       checked_dir = '' if exact && checked_dir.nil?
+      name = ::File.join(checked_dir, name) if checked_dir
 
       map.each do |entry|
         next if entry.name.to_s.empty?
-        next unless checked_dir.nil? || entry.dir.downcase == checked_dir
-        next unless page_match(name, entry.name)
+        path = checked_dir ? ::File.join(entry.dir, entry.name) : entry.name
+        next unless page_match(name, path)
         return entry.page(@wiki, @version)
       end
 
@@ -435,11 +434,11 @@ module Gollum
     # Compare the canonicalized versions of the two names.
     #
     # name     - The human or canonical String page name.
-    # filename - the String filename on disk (including extension).
+    # path     - the String path on disk (including file extension).
     #
     # Returns a Boolean.
-    def page_match(name, filename)
-      if match = self.class.valid_filename?(filename)
+    def page_match(name, path)
+      if match = self.class.valid_filename?(path)
         @wiki.ws_subs.each do |sub|
           return true if Page.cname(name).downcase == Page.cname(match, sub).downcase
         end

--- a/test/test_wiki.rb
+++ b/test/test_wiki.rb
@@ -585,6 +585,16 @@ context "Renames directory traversal" do
     assert_renamed source, @wiki.page("C")
   end
 
+  test "rename page containing space without directories" do
+    # Make sure renames involving spaces work with relative paths.
+    source = @wiki.page("B")
+
+    # B.md => C D.md
+    assert @wiki.rename_page(source, "C D", rename_commit_details)
+
+    assert_renamed source, @wiki.page("C D")
+  end
+
   test "rename page with subdirs" do
     # Make sure renames in subdirectories happen ok
     source = @wiki.paged("H", "G")
@@ -593,6 +603,16 @@ context "Renames directory traversal" do
     assert @wiki.rename_page(source, "G/F", rename_commit_details)
 
     assert_renamed source, @wiki.paged("F", "G")
+  end
+
+  test "rename page containing space with subdir" do
+    # Make sure renames involving spaces in subdirectories happen ok
+    source = @wiki.paged("H", "G")
+
+    # G/H.md => G/F H.md
+    assert @wiki.rename_page(source, "G/F H", rename_commit_details)
+
+    assert_renamed source, @wiki.paged("F H", "G")
   end
 
   test "rename page absolute path is still no-act" do
@@ -622,6 +642,16 @@ context "Renames directory traversal" do
     assert_renamed source, @wiki.page("C")
   end
 
+  test "rename page with space absolute directory" do
+    # Make sure renames involving spaces work with absolute paths.
+    source = @wiki.page("B")
+
+    # B.md => C D.md
+    assert @wiki.rename_page(source, "/C D", rename_commit_details)
+
+    assert_renamed source, @wiki.page("C D")
+  end
+
   test "rename page absolute directory with subdirs" do
     # Make sure renames in subdirectories happen ok
     source = @wiki.paged("H", "G")
@@ -630,6 +660,16 @@ context "Renames directory traversal" do
     assert @wiki.rename_page(source, "/G/F", rename_commit_details)
 
     assert_renamed source, @wiki.paged("F", "G")
+  end
+
+  test "rename page containing space absolute directory with subdir" do
+    # Make sure renames involving spaces in subdirectories happen ok
+    source = @wiki.paged("H", "G")
+
+    # G/H.md => G/F H.md
+    assert @wiki.rename_page(source, "/G/F H", rename_commit_details)
+
+    assert_renamed source, @wiki.paged("F H", "G")
   end
 
   test "rename page relative directory with new dir creation" do
@@ -644,6 +684,18 @@ context "Renames directory traversal" do
     assert_renamed source, new_page
   end
 
+  test "rename page relative directory with new dir creation containing space" do
+    # Make sure renames involving spaces in subdirectories create more subdirectories ok
+    source = @wiki.paged("H", "G")
+
+    # G/H.md => G/K L/F.md
+    assert k = @wiki.rename_page(source, "K L/F", rename_commit_details)
+
+    new_page = @wiki.paged("F", "K L")
+    assert_not_nil new_page
+    assert_renamed source, new_page
+  end
+
   test "rename page absolute directory with subdir creation" do
     # Make sure renames in subdirectories create more subdirectories ok
     source = @wiki.paged("H", "G")
@@ -652,6 +704,18 @@ context "Renames directory traversal" do
     assert @wiki.rename_page(source, "/G/K/F", rename_commit_details)
 
     new_page = @wiki.paged("F", "G/K")
+    assert_not_nil new_page
+    assert_renamed source, new_page
+  end
+
+  test "rename page absolute directory with subdir creation containing space" do
+    # Make sure renames involving spaces in subdirectories create more subdirectories ok
+    source = @wiki.paged("H", "G")
+
+    # G/H.md => G/K L/F.md
+    assert @wiki.rename_page(source, "/G/K L/F", rename_commit_details)
+
+    new_page = @wiki.paged("F", "G/K L")
     assert_not_nil new_page
     assert_renamed source, new_page
   end


### PR DESCRIPTION
This PR fixes a bug where renaming a page to a subdirectory containing spaces would not work correctly. For example renaming `A/C` to `A B/C` would update the repo but the front end would not redirect to the new page.

The fix has been achieved by generally improving the handling of subdirectories containing spaces in `Gollum::Page#find_page_in_tree` by treating the subdirectory and page name as one. I have renamed `filename` to `path` in `Gollum::Page#page_match` to highlight that this method will work on all paths, not just filenames.

I added a few tests for renames with various parts of the path containing spaces. Two of the tests will fail without the fix whereas the remainder will pass regardless. This is because the existing code supports spaces in the page name but not subdirectories.

I'd appreciate a code review before merging this, hence the PR. Hopefully this is a small step towards #11.
