### PR TITLE
Re-enable metadata

### DIFF
--- a/lib/gollum-lib/markup.rb
+++ b/lib/gollum-lib/markup.rb
@@ -650,9 +650,10 @@ module Gollum
     #
     #########################################################################
 
-    # Extract metadata for data and build metadata table. Metadata
-    # is content found between markers, and must
-    # be a valid YAML mapping.
+    # Extract metadata for data and build metadata table.  Metadata consists of
+    # key/value pairs in "key:value" format found between markers.  Each
+    # key/value pair must be on its own line.  Internal whitespace in keys and
+    # values is preserved, but external whitespace is ignored.
     #
     # Because ri and ruby 1.8.7 are awesome, the markers can't
     # be included in this documentation without triggering
@@ -661,8 +662,15 @@ module Gollum
     #
     # Returns the String of formatted data with metadata removed.
     def extract_metadata(data)
-      @metadata = {}
-      data
+      @metadata ||= {}
+      # The markers are `<!-- ---` and `-->`
+      data.gsub(/\<\!--+\s+---(.*?)--+\>/m) do
+        $1.split("\n").each do |line|
+          k, v = line.split(':', 2)
+          @metadata[k.strip] = (v ? v.strip : '') if k
+        end
+        ''
+      end
     end
 
     # Hook for getting the formatted value of extracted tag data.


### PR DESCRIPTION
This is a simplistic Hash parser, but it works for basic metadata
purposes which seems better than having no metadata support at all.  The
following examples show how to set a page title using metadata.

All on one line:

``` ruby
<!-- --- title: My Fantastic Page -->
```

Or split across multiple lines:

``` ruby
<!-- ---
title: My Fantastic Page
-->
```

Notes:
1. Only one key/value pair per line. Multiple lines must be used for
   multiple key/value pairs (though I'm not aware of support for any keys
   other than "title").
2. Keys and values cannot contain embedded newlines.
3. The patch does _not_ HTML-sanitize the key or value portion of the
   metadata.  Presumably metadata is not solely for inclusion in HTML, so
   only the user of the metadata will know whether it needs to be sanitized
   in any way.
