### PR TITLE
Return OpenStruct in `search`

### DIFF
--- a/lib/gollum-lib/wiki.rb
+++ b/lib/gollum-lib/wiki.rb
@@ -594,7 +594,7 @@ module Gollum
       end
 
       results.map do |key,val|
-        OpenStruct.new { :count => val, :name => key }
+        OpenStruct.new :count => val, :name => key
       end
     end
 


### PR DESCRIPTION
Allows for access of `name` like in `Gollum::Page`
