### PR TITLE
Require pathname when needed, should fix gollum/gollum#728.

### DIFF
--- a/lib/gollum-lib/file.rb
+++ b/lib/gollum-lib/file.rb
@@ -1,4 +1,6 @@
 # ~*~ encoding: utf-8 ~*~
+require 'pathname'
+
 module Gollum
   class File
     Wiki.file_class = self


### PR DESCRIPTION
This error seems to be the result of a failure to require 'pathname'.  I think this fixes it, though it's not caught by the tests and isn't reproducible on my machine, so I can't say for sure.
