### PR TITLE
Updating page with the page_file_dir configured will leave a staged commit

### DIFF
--- a/lib/gollum-lib/committer.rb
+++ b/lib/gollum-lib/committer.rb
@@ -133,7 +133,7 @@ module Gollum
     # Returns nothing.
     def update_working_dir(dir, name, format)
       unless @wiki.repo.bare
-        if @wiki.page_file_dir
+        if @wiki.page_file_dir && dir !~ /^#{@wiki.page_file_dir}/
           dir = dir.size.zero? ? @wiki.page_file_dir : ::File.join(@wiki.page_file_dir, dir)
         end
 

--- a/test/test_committer.rb
+++ b/test/test_committer.rb
@@ -63,7 +63,7 @@ context "Wiki" do
   end
 
 
-  test "update working directory with page file directory and subdirectory" do
+  test "update working directory with page file directory and subdirectory for a new page" do
     page_file_dir = "foo"
     dir = "/bar"
     name = "baz"
@@ -77,4 +77,18 @@ context "Wiki" do
     @wiki.repo.git.expects(:checkout).with(anything, anything, anything, "#{page_file_dir}#{dir}/#{name}.md")
     @wiki.write_page(name, format, "foo bar baz", commit_details, dir)
   end
+
+  test "update working directory with page file directory and subdirectory for an existing page" do
+     page_file_dir = "Rivendell"
+     name = "Elrond"
+     format = :markdown
+     @wiki = Gollum::Wiki.new(testpath("examples/lotr.git"), {:page_file_dir => page_file_dir})
+
+     @wiki.repo.stubs(:bare).returns(false)
+     Grit::Index.any_instance.stubs(:commit).returns(true)
+
+     page = @wiki.page(name)
+     @wiki.repo.git.expects(:checkout).at_least(1).with(anything, anything, anything, "#{page_file_dir}/#{name}.md")
+     @wiki.update_page(page, page.name, format, "# Elrond", commit_details())
+   end
 end


### PR DESCRIPTION
A wiki with a page file directory configured will not do a proper checkout during the update working directory process, leaving a staged commit, due to a duplicate page file directory prepended to the path. An existing page retrieved during the update process will already include it's full path, including the page file directory, in the page path so it doesn't need to be added to the dir during the update.
