### PR TITLE
Add support for hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,16 @@ To delete a page and commit the change:
 wiki.delete_page(page, commit)
 ```
 
+Register or unregister a hook to be called after a page commit:
+
+```ruby
+Gollum::Hook.register(:post_commit, :hook_id) do |committer, sha1|
+  # Your code here
+end
+
+Gollum::Hook.unregister(:post_commit, :hook_id)
+```
+
 ## WINDOWS FILENAME VALIDATION
 
 Note that filenames on windows must not contain any of the following characters `\ / : * ? " < > |`. See [this support article](http://support.microsoft.com/kb/177506) for details.

--- a/lib/gollum-lib.rb
+++ b/lib/gollum-lib.rb
@@ -12,6 +12,7 @@ require 'sanitize'
 
 # internal
 require File.expand_path('../gollum-lib/git_access', __FILE__)
+require File.expand_path('../gollum-lib/hook', __FILE__)
 require File.expand_path('../gollum-lib/committer', __FILE__)
 require File.expand_path('../gollum-lib/pagination', __FILE__)
 require File.expand_path('../gollum-lib/blob_entry', __FILE__)

--- a/lib/gollum-lib/committer.rb
+++ b/lib/gollum-lib/committer.rb
@@ -30,6 +30,7 @@ module Gollum
       @wiki      = wiki
       @options   = options
       @callbacks = []
+      after_commit { |*args| Hook.execute(:post_commit, *args) }
     end
 
     # Public: References the Git index for this commit.

--- a/lib/gollum-lib/hook.rb
+++ b/lib/gollum-lib/hook.rb
@@ -1,0 +1,35 @@
+# ~*~ encoding: utf-8 ~*~
+module Gollum
+  class Hook
+    @hooks = {}
+
+    class << self
+      def register(type, id, &block)
+        type_hooks     = @hooks[type] ||= {}
+        type_hooks[id] = block
+      end
+
+      def unregister(type, id)
+        type_hooks = @hooks[type]
+        if type_hooks
+          type_hooks.delete(id)
+          @hooks.delete(type) if type_hooks.empty?
+        end
+      end
+
+      def get(type, id)
+        @hooks.fetch(type, {})[id]
+      end
+
+      def execute(type, *args)
+        type_hooks = @hooks[type]
+        if type_hooks
+          type_hooks.each_value do |block|
+            block.call(*args)
+          end
+        end
+      end
+    end
+
+  end
+end

--- a/test/test_hook.rb
+++ b/test/test_hook.rb
@@ -1,0 +1,75 @@
+# ~*~ encoding: utf-8 ~*~
+path = File.join(File.dirname(__FILE__), 'helper')
+require File.expand_path(path)
+
+context 'Hook' do
+
+  test 'registering a hook' do
+    begin
+      hook = Proc.new {}
+      Gollum::Hook.register(:test, :hook, &hook)
+      assert_same hook, Gollum::Hook.get(:test, :hook)
+    ensure
+      Gollum::Hook.unregister(:test, :hook)
+    end
+  end
+
+  test 'reregistering a hook' do
+    begin
+      hook1 = Proc.new {}
+      hook2 = Proc.new {}
+      Gollum::Hook.register(:test, :hook, &hook1)
+      Gollum::Hook.register(:test, :hook, &hook2)
+      assert_same hook2, Gollum::Hook.get(:test, :hook)
+    ensure
+      Gollum::Hook.unregister(:test, :hook)
+    end
+  end
+
+  test 'unregistering a hook' do
+    begin
+      hook = Proc.new {}
+      Gollum::Hook.register(:test, :hook, &hook)
+      Gollum::Hook.unregister(:test, :hook)
+      assert_nil Gollum::Hook.get(:test, :hook)
+    ensure
+      Gollum::Hook.unregister(:test, :hook)
+    end
+  end
+
+  test 'unregistering a non-existent hook' do
+    Gollum::Hook.unregister(:test, :hook)
+    assert_nil Gollum::Hook.get(:test, :hook)
+  end
+
+  test 'executing hooks' do
+    begin
+      received_args1 = received_args2 = nil
+      hook1          = Proc.new { |*args| received_args1 = args }
+      hook2          = Proc.new { |*args| received_args2 = args }
+      Gollum::Hook.register(:test, :hook1, &hook1)
+      Gollum::Hook.register(:test, :hook2, &hook2)
+      args = [1, '2', :three]
+      Gollum::Hook.execute(:test, *args)
+      assert_equal args, received_args1
+      assert_equal args, received_args2
+    ensure
+      Gollum::Hook.unregister(:test, :hook1)
+      Gollum::Hook.unregister(:test, :hook2)
+    end
+  end
+
+  test 'executing non-existent hooks' do
+    begin
+      received_args = nil
+      hook          = Proc.new { |*args| received_args = args }
+      Gollum::Hook.register(:test, :hook, &hook)
+      args = [1, '2', :three]
+      Gollum::Hook.execute(:test_non_existent, *args)
+      assert_nil received_args
+    ensure
+      Gollum::Hook.unregister(:test, :hook)
+    end
+  end
+
+end


### PR DESCRIPTION
This pull request adds general support for user-defined hooks in the Gollum backend with an initial implementation for post commit hooks. See #12 for discussion.
