### PR TITLE
Catch Grit exceptions and throw new equivalent Gollum errors. Add method...

### DIFF
--- a/lib/gollum-lib.rb
+++ b/lib/gollum-lib.rb
@@ -36,6 +36,14 @@ module Gollum
   def self.assets_path
     ::File.expand_path('gollum/frontend/public', ::File.dirname(__FILE__))
   end
+  
+  def self.set_git_timeout(time)
+    Grit::Git.git_timeout = time
+  end
+  
+  def self.set_git_max_filesize(size)
+    Grit::Git.git_max_size = size
+  end
 
   class Error < StandardError; end
 
@@ -51,5 +59,9 @@ module Gollum
       super(message || "Cannot write #{@dir}/#{@attempted_path}, found #{@dir}/#{@existing_path}.")
     end
   end
+  
+  class InvalidGitRepositoryError < StandardError ; end
+  class NoSuchPathError < StandardError ; end
+  
 end
 

--- a/lib/gollum-lib/git_access.rb
+++ b/lib/gollum-lib/git_access.rb
@@ -13,7 +13,13 @@ module Gollum
     def initialize(path, page_file_dir = nil, bare = false)
       @page_file_dir = page_file_dir
       @path = path
-      @repo = Grit::Repo.new(path, { :is_bare => bare })
+      begin
+        @repo = Grit::Repo.new(path, { :is_bare => bare })
+      rescue Grit::InvalidGitRepositoryError
+        raise Gollum::InvalidGitRepositoryError
+      rescue Grit::NoSuchPathError
+        raise Gollum::NoSuchPatherror
+      end
       clear
     end
 


### PR DESCRIPTION
...s for setting Grit timeout and max filesize. See this issue:

https://github.com/gollum/gollum/issues/733
