### PR TITLE
Removes explicit calls to Grit::Git's catch-all #native method.

### DIFF
--- a/lib/gollum-lib/git_access.rb
+++ b/lib/gollum-lib/git_access.rb
@@ -163,15 +163,13 @@ module Gollum
     #
     # Returns an Array of BlobEntry instances.
     def tree!(sha)
-      tree  = @repo.git.native(:ls_tree,
-        {:r => true, :l => true, :z => true}, sha)
-      if tree.respond_to?(:force_encoding)
-        tree.force_encoding("UTF-8")
+      tree = @repo.lstree(sha, {:recursive => true})
+      items = []
+      tree.each do |entry|
+        if entry[:type] == 'blob'
+          items << BlobEntry.new(entry[:sha], entry[:path], entry[:size], entry[:mode].to_i(8)) 
+        end
       end
-      items = tree.split("\0").inject([]) do |memo, line|
-        memo << parse_tree_line(line)
-      end
-
       if dir = @page_file_dir
         regex = /^#{dir}\//
         items.select { |i| i.path =~ regex }

--- a/lib/gollum-lib/page.rb
+++ b/lib/gollum-lib/page.rb
@@ -259,7 +259,7 @@ module Gollum
     #           :page     - The Integer page number (default: 1).
     #           :per_page - The Integer max count of items to return.
     #           :follow   - Follow's a file across renames, but falls back
-    #                       to a slower Grit native call.  (default: false)
+    #                       to a slower Grit native call (implicit in repo.git.log).  (default: false)
     #
     # Returns an Array of Grit::Commit.
     def versions(options = {})
@@ -267,7 +267,7 @@ module Gollum
         options[:pretty] = 'raw'
         options.delete :max_count
         options.delete :skip
-        log = @wiki.repo.git.native "log", options, @wiki.ref, "--", @path
+        log = @wiki.repo.git.log(options, @wiki.ref, "--", @path)
         Grit::Commit.list_from_string(@wiki.repo, log)
       else
         @wiki.repo.log(@wiki.ref, @path, log_pagination_options(options))

--- a/lib/gollum-lib/wiki.rb
+++ b/lib/gollum-lib/wiki.rb
@@ -751,11 +751,11 @@ module Gollum
     # Returns a String of the reverse Diff to apply.
     def full_reverse_diff_for(page, sha1, sha2 = nil)
       sha1, sha2 = "#{sha1}^", sha1 if sha2.nil?
-      args = [{:R => true}, sha1, sha2]
       if page
-        args << '--' << (page.respond_to?(:path) ? page.path : page.to_s)
+        path = (page.respond_to?(:path) ? page.path : page.to_s)
+        return repo.diff(sha2, sha1, path).first.diff
       end
-      repo.git.native(:diff, *args)
+      repo.diff(sha2, sha1).map{|d| d.diff}.join("\n")
     end
 
     # Creates a reverse diff for the given SHAs.

--- a/test/test_wiki.rb
+++ b/test/test_wiki.rb
@@ -84,14 +84,14 @@ context "Wiki" do
 
   test "gets reverse diff" do
     diff = @wiki.full_reverse_diff('a8ad3c09dd842a3517085bfadd37718856dee813')
-    assert_match "b/Mordor/_Sidebar.md", diff
-    assert_match "b/_Sidebar.md", diff
+    assert_match "a/Mordor/_Sidebar.md", diff
+    assert_match "a/_Sidebar.md", diff
   end
 
   test "gets reverse diff for a page" do
     diff  = @wiki.full_reverse_diff_for('_Sidebar.md', 'a8ad3c09dd842a3517085bfadd37718856dee813')
-    regex = /b\/Mordor\/\_Sidebar\.md/
-    assert_match    "b/_Sidebar.md", diff
+    regex = /a\/Mordor\/\_Sidebar\.md/
+    assert_match    "a/_Sidebar.md", diff
     assert_no_match regex, diff
   end
 


### PR DESCRIPTION
Removing explicit calls to Grit::Git's catch-all #native method makes it easier to implement a git abstraction layer in the future.
