### PR TITLE
Fix typo in `GitAccess#initialize`

### DIFF
--- a/lib/gollum-lib/git_access.rb
+++ b/lib/gollum-lib/git_access.rb
@@ -18,7 +18,7 @@ module Gollum
       rescue Grit::InvalidGitRepositoryError
         raise Gollum::InvalidGitRepositoryError
       rescue Grit::NoSuchPathError
-        raise Gollum::NoSuchPatherror
+        raise Gollum::NoSuchPathError
       end
       clear
     end


### PR DESCRIPTION
i found this in a failing test in my Rugged PR. i think this fixes it. i guess an even better thing would be a failing test to show that i did fix this (if you think that's necessary, let me know and i'll add it).

Thank goodness for failing tests, amirite?
