### PR TITLE
Remove github-markdown dependency from gollum-lib.gemspec

### DIFF
--- a/gollum-lib.gemspec
+++ b/gollum-lib.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency('nokogiri', '~> 1.6.0')
   s.add_dependency('stringex', '~> 2.0.5')
 
+  s.add_development_dependency('github-markdown', '~> 0.5.3')
   s.add_development_dependency('RedCloth', '~> 4.2.9')
   s.add_development_dependency('mocha', '~> 0.13.2')
   s.add_development_dependency('org-ruby', '~> 0.8.1')


### PR DESCRIPTION
Explicit dependency on 'github-markdown' in gemspec makes it difficult to use another Markdown engine (i.e. kramdown), because 'github-markup' gem checks for 'github-markdown' and uses it by default if present.

When this dependency is removed, the user need not touch gollum-lib configuration at all, just include his/her favourite Markdown engine gem, and it is used transparently by 'github-markup' upstream.
