### PR TITLE
Allow binary files to be uploaded

### DIFF
--- a/lib/gollum-lib/committer.rb
+++ b/lib/gollum-lib/committer.rb
@@ -120,7 +120,13 @@ module Gollum
 
       fullpath = fullpath.force_encoding('ascii-8bit') if fullpath.respond_to?(:force_encoding)
 
-      index.add(fullpath, @wiki.normalize(data))
+      begin
+        data = @wiki.normalize(data)
+      rescue ArgumentError => err
+        # Swallow errors that arise from data being binary
+        raise err unless err.message.include?('invalid byte sequence')
+      end
+      index.add(fullpath, data)
     end
 
     # Update the given file in the repository's working directory if there


### PR DESCRIPTION
This fixes https://github.com/gollum/gollum/issues/737

It's not a particularly smart implementation, but it should be fairly future-proof since it doesn't require any enumeration of text or binary formats.

There are no tests for adding binary files, and I don't understand Gollum's testing strategy well enough to add one, but I'd be willing to pair with someone knowledgeable on it.
