### PR TITLE
Remove duplicate rake

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source 'https://rubygems.org'
 
 gemspec
-gem 'rake', '~> 10.0.3'


### PR DESCRIPTION
There's no reason to have rake in both the Gemfile and gemspec, and bundler was complaining about the duplicate.
