### PR TITLE
Added PlainText filter to render .txt files in <pre></pre> block without additional markup (issue https://github.com/gollum/gollum/issues/775).

### DIFF
--- a/lib/gollum-lib/filter/code.rb
+++ b/lib/gollum-lib/filter/code.rb
@@ -5,6 +5,7 @@
 # Render a block of code using the Rouge syntax-highlighter.
 class Gollum::Filter::Code < Gollum::Filter
   def extract(data)
+    return data if @markup.format == :txt
     data.gsub!(/^([ \t]*)(~~~+) ?([^\r\n]+)?\r?\n(.+?)\r?\n\1(~~~+)[ \t\r]*$/m) do
       m_indent = $1
       m_start  = $2 # ~~~

--- a/lib/gollum-lib/filter/plain_text.rb
+++ b/lib/gollum-lib/filter/plain_text.rb
@@ -1,0 +1,15 @@
+# ~*~ encoding: utf-8 ~*~
+
+# Plain Text
+#
+# Render plain text documents in a <pre> block without any special markup.
+
+class Gollum::Filter::PlainText < Gollum::Filter
+
+  def extract(data)
+    @markup.format == :txt ? "<pre>#{CGI.escapeHTML(data)}</pre>" : data
+  end
+
+  def process(data); data ; end
+
+end

--- a/lib/gollum-lib/filter/remote_code.rb
+++ b/lib/gollum-lib/filter/remote_code.rb
@@ -12,7 +12,8 @@ require 'open-uri'
 #              ```language:https://example.com/somefile.txt```
 #
 class Gollum::Filter::RemoteCode < Gollum::Filter
-  def extract data
+  def extract(data)
+    return data if @markup.format == :txt
     data.gsub /^[ \t]*``` ?([^:\n\r]+):((http)?[^`\n\r]+)```/ do
       language = $1
       uri = $2

--- a/lib/gollum-lib/filter/tags.rb
+++ b/lib/gollum-lib/filter/tags.rb
@@ -4,9 +4,7 @@
 class Gollum::Filter::Tags < Gollum::Filter
   # Extract all tags into the tagmap and replace with placeholders.
   def extract(data)
-    if @markup.format == :asciidoc
-      return data
-    end
+    return data if @markup.format == :txt || @markup.format == :asciidoc
     data.gsub!(/(.?)\[\[(.+?)\]\]([^\[]?)/m) do
       if $1 == "'" && $3 != "'"
         "[[#{$2}]]#{$3}"

--- a/lib/gollum-lib/filter/wsd.rb
+++ b/lib/gollum-lib/filter/wsd.rb
@@ -14,6 +14,7 @@ class Gollum::Filter::WSD < Gollum::Filter
   # Extract all sequence diagram blocks into the map and replace with
   # placeholders.
   def extract(data)
+    return data if @markup.format == :txt
     data.gsub(/^\{\{\{\{\{\{ ?(.+?)\r?\n(.+?)\r?\n\}\}\}\}\}\}\r?$/m) do
       id = Digest::SHA1.hexdigest($2)
       @map[id] = { :style => $1, :code => $2 }

--- a/lib/gollum-lib/markup.rb
+++ b/lib/gollum-lib/markup.rb
@@ -12,10 +12,18 @@ module Gollum
     include Helpers
 
     @formats = {}
-
+    
     class << self
-      attr_reader :formats
-
+      
+      # Only use the formats that are specified in config.rb
+      def formats
+        if defined? Gollum::Page::FORMAT_NAMES
+          @formats.select { |_, value| Gollum::Page::FORMAT_NAMES.values.include? value[:name] }
+        else
+          @formats
+        end
+      end
+      
       # Register a file extension and associated markup type
       #
       # ext     - The file extension

--- a/lib/gollum-lib/markups.rb
+++ b/lib/gollum-lib/markups.rb
@@ -10,5 +10,6 @@ module Gollum
     register(:asciidoc,  "AsciiDoc")
     register(:mediawiki, "MediaWiki", :regexp => /(media)?wiki/)
     register(:pod,       "Pod")
+    register(:txt,       "Plain Text")
   end
 end

--- a/lib/gollum-lib/wiki.rb
+++ b/lib/gollum-lib/wiki.rb
@@ -235,7 +235,7 @@ module Gollum
       @allow_uploads        = options.fetch :allow_uploads, false
       @per_page_uploads     = options.fetch :per_page_uploads, false
       @filter_chain         = options.fetch :filter_chain,
-                              [:Metadata, :TOC, :RemoteCode, :Code, :Sanitize, :WSD, :Tags, :Render]
+                              [:Metadata, :PlainText, :TOC, :RemoteCode, :Code, :Sanitize, :WSD, :Tags, :Render]
     end
 
     # Public: check whether the wiki's git repo exists on the filesystem.

--- a/test/test_wiki.rb
+++ b/test/test_wiki.rb
@@ -54,19 +54,19 @@ context "Wiki" do
   test "list pages" do
     pages = @wiki.pages
     assert_equal \
-      ['Bilbo-Baggins.md', 'Boromir.md', 'Elrond.md', 'Eye-Of-Sauron.md', 'Hobbit.md', 'Home.textile', 'My-Precious.md', 'Samwise Gamgee.mediawiki'],
+      ['Bilbo-Baggins.md', 'Boromir.md', 'Elrond.md', 'Eye-Of-Sauron.md', 'Hobbit.md', 'Home.textile', 'My-Precious.md', 'Samwise Gamgee.mediawiki', 'todo.txt'],
       pages.map { |p| p.filename }.sort
   end
 
   test "list files" do
     files = @wiki.files
     assert_equal \
-      ['Data-Two.csv', 'Data.csv', 'Riddles.rd', 'eye.jpg', 'todo.txt'],
+      ['Data-Two.csv', 'Data.csv', 'Riddles.rd', 'eye.jpg'],
       files.map { |p| p.filename }.sort
   end
 
   test "counts pages" do
-    assert_equal 8, @wiki.size
+    assert_equal 9, @wiki.size
   end
 
   test "text_data" do


### PR DESCRIPTION
This PR adds a PlainText filter in order to render .txt files in <pre></pre> block without additional markup (issue https://github.com/gollum/gollum/issues/775). Two things to note:
1) This PR changes the default handling of .txt files in Gollum. They will now be treated as pages instead of files.
2) The PlainText filter is applied in the filter chain after the meta-data filter. Code blocks, tags and other markup will not be parsed if the page is a .txt file. Please review before merging.
