### PR TITLE
Makes Gollum adhere to formatter limitations set in config.rb.

### DIFF
--- a/lib/gollum-lib/markup.rb
+++ b/lib/gollum-lib/markup.rb
@@ -12,10 +12,18 @@ module Gollum
     include Helpers
 
     @formats = {}
-
+    
     class << self
-      attr_reader :formats
-
+      
+      # Only use the formats that are specified in config.rb
+      def formats
+        if defined? Gollum::Page::FORMAT_NAMES
+          @formats.select { |_, value| Gollum::Page::FORMAT_NAMES.values.include? value[:name] }
+        else
+          @formats
+        end
+      end
+      
       # Register a file extension and associated markup type
       #
       # ext     - The file extension

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -48,6 +48,21 @@ context "Markup" do
     end
     assert yielded
   end
+  
+  test "Gollum::Markup#formats returns all formats by default" do
+    assert Gollum::Markup.formats.keys.include?(:asciidoc)
+    assert Gollum::Markup.formats.size > 1
+  end
+  
+  test "Gollum::Markup#formats is limited by Gollum::Page::FORMAT_NAMES" do
+    begin
+      Gollum::Page::FORMAT_NAMES = { :markdown  => "Markdown" }
+      assert Gollum::Markup.formats.keys.include?(:markdown)
+      assert ! Gollum::Markup.formats.keys.include?(:asciidoc)
+    ensure
+      Gollum::Page.send :remove_const, :FORMAT_NAMES
+    end
+  end
 
   #########################################################################
   #


### PR DESCRIPTION
Gollum::Markup.formats now adheres to formatter limitations from config.rb. Fixes issue https://github.com/gollum/gollum/issues/771.
![gollum_issue-771](https://f.cloud.github.com/assets/571173/1935479/32d013b8-7efa-11e3-9068-43dfa04b4ec4.png)
