### PR TITLE
prevent update_page with a rename from clobbering existing files with th...

### DIFF
--- a/lib/gollum-lib/wiki.rb
+++ b/lib/gollum-lib/wiki.rb
@@ -428,7 +428,7 @@ module Gollum
         committer.add(page.path, normalize(data))
       else
         committer.delete(page.path)
-        committer.add_to_index(dir, filename, format, data, :allow_same_ext)
+        committer.add_to_index(dir, filename, format, data)
       end
 
       committer.after_commit do |index, sha|

--- a/test/test_wiki.rb
+++ b/test/test_wiki.rb
@@ -186,7 +186,7 @@ context "Wiki page writing" do
     assert @wiki.page("Gollum")
   end
 
-  test "is not allowed to overwrite file" do
+  test "write page is not allowed to overwrite file" do
     @wiki.write_page("Abc-Def", :markdown, "# Gollum", commit_details)
     assert_raises Gollum::DuplicatePageError do
       @wiki.write_page("ABC DEF", :textile,  "# Gollum", commit_details)
@@ -212,6 +212,15 @@ context "Wiki page writing" do
     assert_equal "Leave now, and never come back!", first_commit.message
     assert_equal "Smeagol", first_commit.author.name
     assert_equal "smeagol@example.org", first_commit.author.email
+  end
+
+  test "update page is not allowed to overwrite file with name change" do
+    @wiki.write_page("Gollum", :markdown, "# Gollum", commit_details)
+    @wiki.write_page("Smeagel", :markdown, "# Smeagel", commit_details)
+    page = @wiki.page("Gollum")
+    assert_raises Gollum::DuplicatePageError do
+      @wiki.update_page(page, 'Smeagel', :markdown, "h1. Gollum", commit_details)
+    end
   end
 
 if $METADATA


### PR DESCRIPTION
Hi, I noticed that if I create a new page with the same name and format as an already existing page, Gollum::DuplicatePageError is raised.  However, if I update a page with a rename and set the new name to an already existing page, it clobbers the already existing page and this was surprising, I expected instead that Gollum::DuplicatePageError would be raised again.  This pull request changes the behavior of Wiki#update_page to raise Gollum::DuplicatePageError when it tries to rename to an already existing page name.  I noticed that the same problem seems to exist with Wiki#rename but I didn't fix it because I'm waiting to see if you guys consider this a bug or not.  The way update_page was coded with an :allow_same_ext getting passed to Comitter#add_to_index leads me to believe perhaps not raising an error is intentional.  If it turns out that it's a bug, let me know and I'd be willing to go back and write the tests to fix rename.  Gollum is awesome! https://twitter.com/timcase/status/422840677127290881.
