### PR TITLE
prevent rename_page with a rename from clobbering existing files with th...

### DIFF
--- a/lib/gollum-lib/wiki.rb
+++ b/lib/gollum-lib/wiki.rb
@@ -380,7 +380,7 @@ module Gollum
       committer = multi_commit ? commit[:committer] : Committer.new(self, commit)
 
       committer.delete(page.path)
-      committer.add_to_index(target_dir, target_name, page.format, page.raw_data, :allow_same_ext)
+      committer.add_to_index(target_dir, target_name, page.format, page.raw_data)
 
       committer.after_commit do |index, sha|
         @access.refresh

--- a/test/test_wiki.rb
+++ b/test/test_wiki.rb
@@ -720,6 +720,15 @@ context "Renames directory traversal" do
     assert_renamed source, new_page
   end
 
+  test "rename page with a name of an already existing page does not clobber that page" do
+    @wiki.write_page("Gollum", :markdown, "# Gollum", commit_details)
+    @wiki.write_page("Smeagel", :markdown, "# Smeagel", commit_details)
+    page = @wiki.page("Gollum")
+    assert_raises Gollum::DuplicatePageError do
+      @wiki.rename_page(page, 'Smeagel', rename_commit_details)
+    end
+  end
+
   def assert_renamed(page_source, page_target)
     @wiki.clear_cache
     assert_nil @wiki.paged(page_source.name, page_source.path)


### PR DESCRIPTION
Hi, this pull request is for the same issue described in a previous pull request (https://github.com/gollum/gollum-lib/pull/57) but for Wiki#rename_page, basically it ensures Gollum::DuplicatePageError is thrown if there is an attempt to rename a page with the same name as an already existing page.
