### PR TITLE
Long-standing bug fix on [[include]] feature which wasn't allowing subpages.

### DIFF
--- a/lib/gollum-lib/filter/tags.rb
+++ b/lib/gollum-lib/filter/tags.rb
@@ -95,16 +95,17 @@ class Gollum::Filter::Tags < Gollum::Filter
   def process_include_tag(tag)
     return unless /^include:/.match(tag)
     page_name = tag[8..-1]
+    resolved_page_name =  ::File.expand_path(page_name, "/"+@markup.dir)
 
     if @markup.include_levels > 0
-      page = @markup.wiki.page(page_name)
+      page = find_page_from_name(resolved_page_name)
       if page
         page.formatted_data(@markup.encoding, @markup.include_levels-1)
       else
-        html_error("Cannot include #{process_page_link_tag(page_name)} - does not exist yet")
+        html_error("Cannot include #{process_page_link_tag(resolved_page_name)} - does not exist yet")
       end
     else
-      html_error("Too many levels of included pages, will not include #{process_page_link_tag(page_name)}")
+      html_error("Too many levels of included pages, will not include #{process_page_link_tag(resolved_page_name)}")
     end
   end
 

--- a/lib/gollum-lib/markup.rb
+++ b/lib/gollum-lib/markup.rb
@@ -50,6 +50,7 @@ module Gollum
     attr_reader   :name
     attr_reader   :include_levels
     attr_reader   :to_xml_opts
+    attr_reader   :dir
 
     # Initialize a new Markup object.
     #


### PR DESCRIPTION
Allow [[include:]] directive to specify relative and subpage paths.  Fixes gollum/gollum#765.
