### PR TITLE
fix process code block bug

### DIFF
--- a/lib/gollum-lib/filter/code.rb
+++ b/lib/gollum-lib/filter/code.rb
@@ -35,7 +35,7 @@ class Gollum::Filter::Code < Gollum::Filter
       "#{m_indent}#{id}" # print the SHA1 ID with the proper indentation
     end
 
-    data.gsub!(/^([ \t]*)``` ?([^\r\n]+)?\r?\n(.+?)\r?\n\1```[ \t]*\r?$/m) do
+    data.gsub!(/^([ \t]{0,3})``` ?([^\r\n]+)?\r?\n(.+?)\r?\n\1```[ \t]*\r?$/m) do
       lang   = $2 ? $2.strip : nil
       id     = Digest::SHA1.hexdigest("#{lang}.#{$3}")
       cached = @markup.check_cache(:code, id)


### PR DESCRIPTION
when code block have ```ruby content will be replaced, it's not correctly. Should keep raw content
