### PR TITLE
766 omit first H1 from TOC

### DIFF
--- a/lib/gollum-lib/filter/toc.rb
+++ b/lib/gollum-lib/filter/toc.rb
@@ -5,7 +5,10 @@ class Gollum::Filter::TOC < Gollum::Filter
   def process(data)
     doc = Nokogiri::HTML::DocumentFragment.parse(data)
     toc = nil
-    doc.css('h1,h2,h3,h4,h5,h6').each do |h|
+    doc.css('h1,h2,h3,h4,h5,h6').each_with_index do |h, i|
+      # omit the first H1 from the TOC
+      next if i == 0 and h.name =~ /[Hh]1/
+      
       # must escape "
       h_name = h.content.gsub(' ','-').gsub('"','%22')
 


### PR DESCRIPTION
Tested it, works as requested in gollum/gollum#766.
- first H1 is omitted from TOC
- second H1 is included in TOC
- H2/3/4/5/6 after first H1 is included in TOC
- all H1's after the first one are included in TOC

:+1: 
