### PR TITLE
Fix tests on rouge v1.3.3

### DIFF
--- a/lib/gollum-lib/filter/code.rb
+++ b/lib/gollum-lib/filter/code.rb
@@ -81,7 +81,8 @@ class Gollum::Filter::Code < Gollum::Filter
           hl_code = formatter.format(lexer.lex(code))
           hl_code = "<pre class='highlight'><span class='err'>#{CGI.escapeHTML(hl_code)}</span></pre>"
         else
-          hl_code = Rouge.highlight(code, lang, 'html')  
+          hl_code = Rouge.highlight(code, lang, 'html').
+            sub(/<\/pre>\n\z/, '</pre>')
         end
       rescue
         hl_code = code


### PR DESCRIPTION
Because of change in rouge v1.3.3(jayferd/rouge@f8fcf193085e99c513f8167750bb4f33af9fa9a9), gollum-lib tests failed(https://travis-ci.org/gollum/gollum-lib/builds/22156117). 
