### PR TITLE
Fix test warnings

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -13,6 +13,9 @@ require 'minitest/reporters'
 # internal
 require File.expand_path('../assertions', __FILE__)
 
+# Fix locale warnings
+I18n.enforce_available_locales = false
+
 MiniTest::Reporters.use!
 
 dir = File.dirname(File.expand_path(__FILE__))

--- a/test/test_file_view.rb
+++ b/test/test_file_view.rb
@@ -54,16 +54,19 @@ def view pages
   Gollum::FileView.new( pages ).render_files
 end
 
-@@test_path = File.expand_path( '../file_view/' , __FILE__ ) + '/'
+
+def test_path
+  @test_path ||= File.expand_path( '../file_view/' , __FILE__ ) + '/'
+end
 
 def read file
-  File.read @@test_path + file + '.txt'
+  File.read test_path + file + '.txt'
 end
 
 # For creating expected files.
 # write name, actual
 def write file, content
-  File.open(@@test_path + file + '.txt', 'w') do | f |
+  File.open(test_path + file + '.txt', 'w') do | f |
     f.write content
   end
 end

--- a/test/test_page.rb
+++ b/test/test_page.rb
@@ -110,22 +110,22 @@ context "Page" do
     assert_equal "モルドール", Gollum::Page.cname("モルドール")
   end
 
-  test "title from filename with normal contents" do
+  test "title from filename with normal contents 1" do
     page = @wiki.page('Bilbo Baggins')
     assert_equal 'Bilbo Baggins', page.title
   end
 
-  test "title from filename with html contents" do
+  test "title from filename with html contents 1" do
     page = @wiki.page('My <b>Precious', '0ed8cbe0a25235bd867e65193c7d837c66b328ef')
     assert_equal 'My Precious', page.title
   end
 
-  test "title from filename with normal contents" do
+  test "title from filename with normal contents 2" do
     page = @wiki.page('Home')
     assert_equal "Home", page.title
   end
 
-  test "title from filename with html contents" do
+  test "title from filename with html contents 2" do
     page = @wiki.page('Eye Of Sauron')
     assert_equal "Eye Of Sauron", page.title
   end

--- a/test/test_unicode.rb
+++ b/test/test_unicode.rb
@@ -15,7 +15,7 @@ context "Unicode Support" do
     FileUtils.rm_rf(@path)
   end
 
-  test "create and read non-latin page with anchor" do
+  test "create and read non-latin page with anchor 1" do
     @wiki.write_page("test", :markdown, "# 한글")
 
     page = @wiki.page("test")
@@ -48,7 +48,7 @@ context "Unicode Support" do
       assert_match /<h1>#{text}<a class="anchor" id="#{text}" href="##{text}"><\/a><\/h1>/,   output
   end
 
-  test "create and read non-latin page with anchor" do
+  test "create and read non-latin page with anchor 2" do
     # href="#한글"
     # href="#%ED%95%9C%EA%B8%80"
     check_h1 '한글', '1'
@@ -57,7 +57,7 @@ context "Unicode Support" do
     check_h1 'Synhtèse', '2'
   end
 
-  test "create and read non-latin page with anchor 2" do
+  test "create and read non-latin page with anchor 3" do
     @wiki.write_page("test", :markdown, "# \"La\" faune d'Édiacara")
 
     page = @wiki.page("test")


### PR DESCRIPTION
Fixed:
[deprecated] I18n.enforce_available_locales will default to true in the future. If you really want to skip validation of your locale you can set I18n.enforce_available_locales = false to avoid this message.
/Users/user/woven/github/gollum-lib/test/test_file_view.rb:57: warning: class variable access from toplevel
test/unit warning: method #Class:0x007fb591a50c00#test_title_from_filename_with_normal_contents is redefined
test/unit warning: method #Class:0x007fb591a50c00#test_title_from_filename_with_html_contents is redefined
test/unit warning: method #Class:0x007fb591a28f98#test_create_and_read_non_latin_page_with_anchor is redefined
