### PR TITLE
Added wiki#latest_changes method for global wiki history view.

### DIFF
--- a/lib/gollum-lib/wiki.rb
+++ b/lib/gollum-lib/wiki.rb
@@ -628,6 +628,17 @@ module Gollum
       @repo.log(@ref, nil, log_pagination_options(options))
     end
 
+    # Returns the latest changes in the wiki (globally)
+    #
+    # options - The options Hash:
+    #           :max_count  - The Integer number of items to return.
+    #
+    # Returns an Array of Grit::Commit.
+    def latest_changes(options={})
+      max_count = options.fetch(:max_count, 10)      
+      @repo.log(@ref, nil, options)
+    end
+    
     # Public: Refreshes just the cached Git reference data.  This should
     # be called after every Gollum update.
     #

--- a/test/test_wiki.rb
+++ b/test/test_wiki.rb
@@ -69,6 +69,10 @@ context "Wiki" do
     assert_equal 9, @wiki.size
   end
 
+  test "latest changes in repo" do
+    assert_equal @wiki.latest_changes({:max_count => 1}).first.id, "874f597a5659b4c3b153674ea04e406ff393975e"
+  end
+  
   test "text_data" do
     wiki = Gollum::Wiki.new(testpath("examples/yubiwa.git"))
     if String.instance_methods.include?(:encoding)


### PR DESCRIPTION
Adds a latest_changes method to wiki in preparation of global history view (https://github.com/gollum/gollum/issues/707).
