### PR TITLE
fix Release 2.0.0 breaks [[_TOC_]] #64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1
+  - 2.1.0
   - 2.1.1
 before_install:
  - sudo apt-get update


### PR DESCRIPTION
fix Release 2.0.0 breaks `[[_TOC_]]` #64
