### PR TITLE
Do not mutate parameters passed in from the outside

### DIFF
--- a/lib/gollum-lib/wiki.rb
+++ b/lib/gollum-lib/wiki.rb
@@ -322,19 +322,19 @@ module Gollum
     # Gollum::Committer instance if this is part of a batch update.
     def write_page(name, format, data, commit = {}, dir = '')
       # spaces must be dashes
-      name.gsub!(' ', '-')
-      dir.gsub!(' ', '-')
+      sanitized_name = name.gsub(' ', '-')
+      sanitized_dir  = dir.gsub(' ', '-')
 
       multi_commit = !!commit[:committer]
       committer    = multi_commit ? commit[:committer] : Committer.new(self, commit)
 
-      filename = Gollum::Page.cname(name)
+      filename = Gollum::Page.cname(sanitized_name)
 
-      committer.add_to_index(dir, filename, format, data)
+      committer.add_to_index(sanitized_dir, filename, format, data)
 
       committer.after_commit do |index, sha|
         @access.refresh
-        index.update_working_dir(dir, filename, format)
+        index.update_working_dir(sanitized_dir, filename, format)
       end
 
       multi_commit ? committer : committer.commit

--- a/test/test_wiki.rb
+++ b/test/test_wiki.rb
@@ -197,6 +197,12 @@ context "Wiki page writing" do
     end
   end
 
+  test "write_page does not mutate input parameters" do
+    name = "Hello There"
+    @wiki.write_page(name, :markdown, 'content', commit_details)
+    assert_equal name, "Hello There"
+  end
+
   test "update_page" do
     @wiki.write_page("Gollum", :markdown, "# Gollum", commit_details)
     page = @wiki.page("Gollum")


### PR DESCRIPTION
wiki.write_page mutates the name and the dir parameters passed in from the outside through `gsub!`. This can have unexpected (and hard to track down) results if you hang on to that variable for some reason or if you assert on its value.

Replaced it with gsub and added a test.
