### PR TITLE
Removes err highlighting for undefined code blocks

### DIFF
--- a/lib/gollum-lib/filter/code.rb
+++ b/lib/gollum-lib/filter/code.rb
@@ -85,6 +85,9 @@ class Gollum::Filter::Code < Gollum::Filter
         end
       else # Rouge
         begin
+          # if `lang` was not defined then assume plaintext
+          # if `lang` is defined but cannot be found then wrap it and escape it
+          lang ||= 'plaintext'
           if Rouge::Lexer.find(lang).nil?
             lexer     = Rouge::Lexers::PlainText.new
             formatter = Rouge::Formatters::HTML.new(:wrap => false)

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -222,7 +222,7 @@ context "Markup" do
         DATA
         ), commit_details)
     output   = @wiki.page(page).formatted_data
-    expected = %Q{<pre><code>      <pre class=\"highlight\"><span class=\"err\">rot13='tr '\\''A-Za-z'\\'' '\\''N-ZA-Mn-za-m'\\'</span></pre>\n</code></pre>}
+    expected = %Q{<pre><code>      <pre class=\"highlight\">rot13='tr '\\''A-Za-z'\\'' '\\''N-ZA-Mn-za-m'\\'</pre>\n</code></pre>}
     assert_html_equal expected, output
   end
 
@@ -235,7 +235,7 @@ context "Markup" do
 ~~~
       ), commit_details)
     output   = @wiki.page(page).formatted_data
-    expected = %Q{<pre class=\"highlight\"><span class=\"err\">'hi'</span></pre>}
+    expected = %Q{<pre class=\"highlight\">'hi'</pre>}
 
     assert_html_equal expected, output
   end
@@ -644,7 +644,7 @@ context "Markup" do
 
   test "code blocks with ascii characters" do
     content = "a\n\n```\n├─foo\n```\n\nb"
-    output  = %(<p>a</p><preclass=\"highlight\"><spanclass=\"err\">├─foo</span></pre><p>b</p>)
+    output  = %(<p>a</p><preclass=\"highlight\">├─foo</pre><p>b</p>)
     compare(content, output)
   end
 


### PR DESCRIPTION
When the language for a code block is not defined and you are using Rouge for highlighting it will style everything with an `err` style and CGI escape the entire code block. This can be problematic for shell code blocks for example, `$ command --do --things 2> \dev\null` is rendered `$ command --do --things 2&gt; \dev\null`.

This pull request updates code filter to use the PlainText lexar by default if none is defined. It maintains the present settings if an unknown language is supplied.
