### PR TITLE
Use protocol relative URL to embed wsd on https wiki to silence browser warning

### DIFF
--- a/lib/gollum-lib/filter/wsd.rb
+++ b/lib/gollum-lib/filter/wsd.rb
@@ -44,7 +44,7 @@ class Gollum::Filter::WSD < Gollum::Filter
   def render_wsd(code, style)
     response = Net::HTTP.post_form(URI.parse(WSD_URL), 'style' => style, 'message' => code)
     if response.body =~ /img: "(.+)"/
-      url = "http://www.websequencediagrams.com/#{$1}"
+      url = "//www.websequencediagrams.com/#{$1}"
       "<img src=\"#{url}\" />"
     else
       puts response.body

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -716,7 +716,7 @@ np.array([[2,2],[1,3]],np.float)
 
   test "sequence diagram blocks" do
     content = "a\n\n{{{{{{default\nalice->bob: Test\n}}}}}}\n\nb"
-    output  = /.*<img src="http:\/\/www\.websequencediagrams\.com\/\?img=\w{9}" \/>.*/
+    output  = /.*<img src="\/\/www\.websequencediagrams\.com\/\?img=\w{9}" \/>.*/
 
     index = @wiki.repo.index
     index.add("Bilbo-Baggins.md", content)


### PR DESCRIPTION
www.websequencediagrams.com is accepted both http and https URL, but Gollum use http URL only.
I got a problem using wsd on our https hosted Gollum wiki.
