### PR TITLE
Update gitlab-grit dependency to 2.7.1

### DIFF
--- a/gollum-lib.gemspec
+++ b/gollum-lib.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ['--charset=UTF-8']
   s.extra_rdoc_files = %w[README.md LICENSE]
 
-  s.add_dependency 'gitlab-grit', '~> 2.6.5'
+  s.add_dependency 'gitlab-grit', '~> 2.7.1'
   s.add_dependency 'rouge', '~> 1.3.3'
   s.add_dependency 'nokogiri', '~> 1.6.1'
   s.add_dependency 'stringex', '~> 2.5.1'


### PR DESCRIPTION
Changes to gitlab-grit since 2.6.5 included below.

== 2.7.1
- Suppress 'unkown header' warnings
- Add process.out to CommandFailed error

== 2.7.0
- Remove the `chdir:` option for thread-safety
- Automatically set the `--work-tree=` Git option

== 2.6.9
- Fix commit diff issue. It shows empty diff for commit when files
- have changed mode

== 2.6.8
- Fix problem with generating archives

== 2.6.7
- Rescue compatibility errors

== 2.6.6
- Improve encoding
