### PR TITLE
Update dependencies

### DIFF
--- a/gollum-lib.gemspec
+++ b/gollum-lib.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'nokogiri', '~> 1.6.1'
   s.add_dependency 'stringex', '~> 2.5.1'
   s.add_dependency 'sanitize', '~> 2.1.0'
-  s.add_dependency 'github-markup', '~> 1.1.0'
+  s.add_dependency 'github-markup', '~> 1.3.0'
 
   s.add_development_dependency 'org-ruby', '~> 0.9.3'
   s.add_development_dependency 'github-markdown', '~> 0.6.5'


### PR DESCRIPTION
- github-markup 1.3.0

I tried to update `rouge` but they made some changes.
Code block are now using `<code>` instead of `<pre>` and as a result 13 tests are failing:

```
  "<pre class=\"highlight\"><span class=\"s1\">'hi'</span></pre>" expected to be HTML equivalent to "<pre><code class=\"highlight\"><span class=\"s1\">'hi'</span></code></pre>\n\n".
```

Ref #93
