### PR TITLE
Add ancestry to TOC anchors (take 3)

### DIFF
--- a/lib/gollum-lib/filter/toc.rb
+++ b/lib/gollum-lib/filter/toc.rb
@@ -5,58 +5,101 @@ class Gollum::Filter::TOC < Gollum::Filter
   end
 
   def process(data)
-    doc          = Nokogiri::HTML::DocumentFragment.parse(data)
-    toc          = nil
-    anchor_names = {}
 
-    doc.css('h1,h2,h3,h4,h5,h6').each do |h|
-      # must escape "
-      h_name               = h.content.gsub(' ', '-').gsub('"', '%22')
-      next if h_name.empty?
+    @doc               = Nokogiri::HTML::DocumentFragment.parse(data)
+    @toc               = nil
+    @anchor_names      = {}
+    @current_ancestors = ""
 
-      # Ensure repeat anchors have a unique prefix or the
-      # toc will break
-      anchor_names[h_name] = 0 if anchor_names[h_name].nil?
-      anchor_names[h_name] += 1
+    @doc.css('h1,h2,h3,h4,h5,h6').each do |header|
+      next if header.content.empty?
 
-      anchor_prefix_number = anchor_names[h_name]
-      if anchor_prefix_number > 1
-        h_name = anchor_prefix_number.to_s + '-' + h_name
-      end
-
-      level = h.name.gsub(/[hH]/, '').to_i
-
-      # Add anchors
-      anchor_element = %Q(<a class="anchor" id="#{h_name}" href="##{h_name}"><i class="fa fa-link"></i></a>)
-      # Add anchor element as the first child (before h.content)
-      h.children.before anchor_element
-
-      # Build TOC
-      toc        ||= Nokogiri::XML::DocumentFragment.parse('<div class="toc"><div class="toc-title">Table of Contents</div></div>')
-      tail       ||= toc.child
-      tail_level ||= 0
-
-      while tail_level < level
-        node       = Nokogiri::XML::Node.new('ul', doc)
-        tail       = tail.add_child(node)
-        tail_level += 1
-      end
-      while tail_level > level
-        tail       = tail.parent
-        tail_level -= 1
-      end
-      node = Nokogiri::XML::Node.new('li', doc)
-      # % -> %25 so anchors work on Firefox. See issue #475
-      node.add_child(%Q{<a href="##{h_name}">#{h.content}</a>})
-      tail.add_child(node)
+      anchor_name = generate_anchor_name(header)
+      
+      add_anchor_to_header header, anchor_name
+      add_entry_to_toc     header, anchor_name
+     end
+ 
+    @toc  = @toc.to_xml(@markup.to_xml_opts) if @toc != nil
+    data  = @doc.to_xml(@markup.to_xml_opts)
+ 
+    @markup.toc = @toc
+     data.gsub("[[_TOC_]]") do
+      @toc.nil? ? '' : @toc
     end
+  end
 
-    toc  = toc.to_xml(@markup.to_xml_opts) if toc != nil
-    data = doc.to_xml(@markup.to_xml_opts)
+  private
 
-    @markup.toc = toc
-    data.gsub("[[_TOC_]]") do
-      toc.nil? ? '' : toc
+  # Generates the anchor name from the given header element 
+  # removing all non alphanumeric characters, replacing them
+  # with single dashes.  
+  #
+  # Generates heading ancestry prefixing the headings
+  # ancestor names to the generated name.
+  #
+  # Prefixes duplicate anchors with an index
+  def generate_anchor_name(header)
+    name = header.content
+    level = header.name.gsub(/[hH]/, '').to_i
+
+    # normalize the header name
+    name.gsub!(/[^\d\w\u00C0-\u1FFF\u2C00-\uD7FF]/, "-")
+    name.gsub!(/-+/, "-")
+    name.gsub!(/^-/, "")
+    name.gsub!(/-$/, "")
+    name.downcase!
+
+    anchor_name = name
+
+    # Set and/or add the ancestors to the name
+    @current_ancestors = name if level == 1
+    anchor_name = (level == 1) ? name : "#{@current_ancestors}_#{name}"
+    @current_ancestors+= "_#{name}" if level > 1
+
+    # Ensure duplicate anchors have a unique prefix or the toc will break
+    index = increment_anchor_index(anchor_name)
+    anchor_name = "#{index}-#{anchor_name}" unless index.zero? # if the index is zero this name is unique
+
+    anchor_name
+  end
+
+  # Creates an anchor element with the given name and adds it before
+  # the given header element.
+  def add_anchor_to_header(header, name)
+    anchor_element = %Q(<a class="anchor" id="#{name}" href="##{name}"><i class="fa fa-link"></i></a>)
+    header.children.before anchor_element # Add anchor element before the header
+  end
+
+  # Adds an entry to the TOC for the given header.  The generated entry
+  # is a link to the given anchor name
+  def add_entry_to_toc(header, name)
+    @toc        ||= Nokogiri::XML::DocumentFragment.parse('<div class="toc"><div class="toc-title">Table of Contents</div></div>')
+    tail        ||= @toc.child
+    tail_level  ||= 0
+
+    level = header.name.gsub(/[hH]/, '').to_i
+
+    while tail_level < level
+      node       = Nokogiri::XML::Node.new('ul', @doc)
+      tail       = tail.add_child(node)
+      tail_level += 1
     end
+    
+    while tail_level > level
+      tail       = tail.parent
+      tail_level -= 1
+     end
+    node = Nokogiri::XML::Node.new('li', @doc)
+    # % -> %25 so anchors work on Firefox. See issue #475
+    node.add_child(%Q{<a href="##{name}">#{header.content}</a>})
+    tail.add_child(node)
+  end
+
+  # Increments the number of anchors with the given name
+  # and returns the current index
+  def increment_anchor_index(name)
+    @anchor_names = {} if @anchor_names.nil?
+    @anchor_names[name].nil? ? @anchor_names[name] = 0 : @anchor_names[name] += 1
   end
 end

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -880,6 +880,29 @@ __TOC__
     compare(content, output, :markdown)
   end
 
+  test "anchor names are normalized" do
+    content = <<-MARKDOWN
+__TOC__
+# Summary '"' stuff
+# Summary !@#$%^&*() stuff
+    MARKDOWN
+
+    output = "<p><strong>TOC</strong></p>\n\n<h1><a class=\"anchor\" id=\"Summary-stuff\" href=\"#Summary-stuff\"><i class=\"fa fa-link\"></i></a>Summary '\"' stuff</h1>\n\n<h1><a class=\"anchor\" id=\"2-Summary-stuff\" href=\"#2-Summary-stuff\"><i class=\"fa fa-link\"></i></a>Summary !@#$%^&*() stuff</h1>"
+    compare(content, output, :markdown)
+  end
+
+  test 'anchor names contain the ancestor' do
+    content = <<-MARKDOWN
+__TOC__
+# Summary
+## Horse
+    MARKDOWN
+
+    output = "<p><strong>TOC</strong></p>\n\n<h1><a class=\"anchor\" id=\"Summary\" href=\"#Summary\"><i class=\"fa fa-link\"></i></a>Summary</h1>\n\n<h2><a class=\"anchor\" id=\"Summary-horse\" href=\"#Summary-horse\"><i class=\"fa fa-link\"></i></a>Horse</h1>"
+    compare(content, output, :markdown)
+  end
+
+
   if ENV['ASCIIDOC']
     #########################################################################
     # Asciidoc

--- a/test/test_unicode.rb
+++ b/test/test_unicode.rb
@@ -83,8 +83,8 @@ context "Unicode Support" do
     anchors = h1 / :a
     assert_equal 1, h1s.size
     assert_equal 1, anchors.size
-    assert_equal %q(#%22La%22-faune-d'Édiacara), anchors[0]['href']
-    assert_equal %q(%22La%22-faune-d'Édiacara), anchors[0]['id']
+    assert_equal %q(#la-faune-d-Édiacara), anchors[0]['href']
+    assert_equal %q(la-faune-d-Édiacara), anchors[0]['id']
     assert_equal 'anchor', anchors[0]['class']
     assert_equal '', anchors[0].text
   end


### PR DESCRIPTION
Fixes gollum/gollum#678.

OK take 3; merging into the `rc` branch now.  Fixed syntax errors from #108.  I already did a test merge on my machine and there is a conflict.
