### PR TITLE
Adds support for relative links. Closes https://github.com/gollum/gollum/issues/868 .

### DIFF
--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -191,9 +191,20 @@ context "Markup" do
 
   test "external page link" do
     @wiki.write_page("Bilbo Baggins", :markdown, "a [[http://example.com]] b", commit_details)
-
     page = @wiki.page("Bilbo Baggins")
     assert_html_equal "<p>a <a href=\"http://example.com\">http://example.com</a> b</p>", page.formatted_data
+  end
+  
+  test "external page link with different text" do
+    @wiki.write_page("Bilbo Baggins", :markdown, "a [[Words|http://example.com]] b", commit_details)
+    page = @wiki.page("Bilbo Baggins")
+    assert_html_equal "<p>a <a href=\"http://example.com\">Words</a> b</p>", page.formatted_data
+  end
+
+  test "external page link with agnostic protocol" do
+    @wiki.write_page("Bilbo Baggins", :markdown, "a [[Words|//example.com]] b", commit_details)
+    page = @wiki.page("Bilbo Baggins")
+    assert_html_equal "<p>a <a href=\"//example.com\">Words</a> b</p>", page.formatted_data
   end
 
   test "page link with different text" do


### PR DESCRIPTION
Introduces a new process_external_link_tag(tag) method in the tags filter. Allows all protocols allowed by Gollum:Sanitization for external links.
