### PR TITLE
Bring dependencies up to date and fix tests accordingly. Closes #93.

### DIFF
--- a/gollum-lib.gemspec
+++ b/gollum-lib.gemspec
@@ -22,32 +22,32 @@ Gem::Specification.new do |s|
   s.rdoc_options = ['--charset=UTF-8']
   s.extra_rdoc_files = %w[README.md LICENSE]
 
-  s.add_dependency 'rouge', '~> 1.3.3'
-  s.add_dependency 'nokogiri', '~> 1.6.1'
+  s.add_dependency 'rouge', '~> 1.7.4'
+  s.add_dependency 'nokogiri', '~> 1.6.4'
   s.add_dependency 'stringex', '~> 2.5.1'
   s.add_dependency 'sanitize', '~> 2.1.0'
-  s.add_dependency 'github-markup', '~> 1.3.0'
+  s.add_dependency 'github-markup', '~> 1.3.1'
 
-  s.add_development_dependency 'org-ruby', '~> 0.9.3'
-  s.add_development_dependency 'github-markdown', '~> 0.6.5'
+  s.add_development_dependency 'org-ruby', '~> 0.9.9'
+  s.add_development_dependency 'github-markdown', '~> 0.6.7'
   s.add_development_dependency 'RedCloth', '~> 4.2.9'
-  s.add_development_dependency 'mocha', '~> 1.0.0'
+  s.add_development_dependency 'mocha', '~> 1.1.0'
   s.add_development_dependency 'shoulda', '~> 3.5.0'
   s.add_development_dependency 'wikicloth', '~> 0.8.1'
-  s.add_development_dependency 'rake', '~> 10.2.2'
-  s.add_development_dependency 'pry', '~> 0.9.12'
+  s.add_development_dependency 'rake', '~> 10.4.0'
+  s.add_development_dependency 'pry', '~> 0.10.1'
   # required by pry
   s.add_development_dependency 'rb-readline', '~> 0.5.1'
   # updating minitest-reporters requires a new minitest which fails with gollum's tests.
   s.add_development_dependency 'minitest-reporters', '~> 0.14.16'
   s.add_development_dependency 'nokogiri-diff', '~> 0.2.0'
   # required by guard
-  s.add_development_dependency 'guard', '~> 2.6.0'
-  s.add_development_dependency 'guard-minitest', '~> 2.2.0'
+  s.add_development_dependency 'guard', '~> 2.8.2'
+  s.add_development_dependency 'guard-minitest', '~> 2.3.2'
   s.add_development_dependency 'rb-inotify', '~> 0.9.3'
   s.add_development_dependency 'rb-fsevent', '~> 0.9.4'
   s.add_development_dependency 'rb-fchange', '~> 0.0.6'
-  s.add_development_dependency 'twitter_cldr', '~> 2.4.2'
+  s.add_development_dependency 'twitter_cldr', '~> 3.1.0'
   # = MANIFEST =
   s.files = %w[
     Gemfile

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -239,7 +239,7 @@ context "Markup" do
         DATA
         ), commit_details)
     output   = @wiki.page(page).formatted_data
-    expected = %Q{<pre><code>      <pre class=\"highlight\">rot13='tr '\\''A-Za-z'\\'' '\\''N-ZA-Mn-za-m'\\'</pre>\n</code></pre>}
+    expected = %Q{<pre><code>      <pre class=\"highlight\"><code>rot13='tr '\\''A-Za-z'\\'' '\\''N-ZA-Mn-za-m'\\'</code></pre>\n</code></pre>}
     assert_html_equal expected, output
   end
 
@@ -252,7 +252,7 @@ context "Markup" do
 ~~~
       ), commit_details)
     output   = @wiki.page(page).formatted_data
-    expected = %Q{<pre class=\"highlight\">'hi'</pre>}
+    expected = %Q{<pre class=\"highlight\"><code>'hi'</code></pre>}
 
     assert_html_equal expected, output
   end
@@ -265,7 +265,7 @@ context "Markup" do
 ~~~
       ), commit_details)
     output   = @wiki.page(page).formatted_data
-    expected = %Q{<pre class=\"highlight\"><span class=\"s1\">'hi'</span></pre>}
+    expected = %Q{<pre class=\"highlight\"><code><span class=\"s1\">'hi'</span></code></pre>}
     assert_html_equal expected, output
   end
 
@@ -278,7 +278,7 @@ context "Markup" do
 ~~~
       ), commit_details)
     output   = @wiki.page(page).formatted_data
-    expected = %Q{<pre class=\"highlight\"><span class=\"s1\">'hi'</span></pre>}
+    expected = %Q{<pre class=\"highlight\"><code><span class=\"s1\">'hi'</span></code></pre>}
 
     assert_html_equal expected, output
   end
@@ -293,7 +293,7 @@ context "Markup" do
 ~~~~~~
       ), commit_details)
     output   = @wiki.page(page).formatted_data
-    expected = %Q{<pre class=\"highlight\"><span class=\"o\">~~</span>\n<span class=\"s1\">'hi'</span><span class=\"o\">~</span></pre>}
+    expected = %Q{<pre class=\"highlight\"><code><span class=\"o\">~~</span>\n<span class=\"s1\">'hi'</span><span class=\"o\">~</span></code></pre>}
 
     assert_html_equal expected, output
   end
@@ -605,7 +605,7 @@ context "Markup" do
 
   test "regular code blocks" do
     content = "a\n\n```ruby\nx = 1\n```\n\nb"
-    output  = %Q{<p>a</p>\n\n<pre class=\"highlight\"><span class=\"n\">x</span> <span class=\"o\">=</span> <span class=\"mi\">1</span></pre>\n\n<p>b</p>}
+    output  = %Q{<p>a</p>\n\n<pre class=\"highlight\"><code><span class=\"n\">x</span> <span class=\"o\">=</span> <span class=\"mi\">1</span></code></pre>\n\n<p>b</p>}
 
     index = @wiki.repo.index
     index.add("Bilbo-Baggins.md", content)
@@ -618,7 +618,7 @@ context "Markup" do
 
   test "code blocks with carriage returns" do
     content = "a\r\n\r\n```ruby\r\nx = 1\r\n```\r\n\r\nb"
-    output  = %Q{<p>a</p>\n\n<pre class=\"highlight\"><span class=\"n\">x</span> <span class=\"o\">=</span> <span class=\"mi\">1</span></pre>\n\n<p>b</p>}
+    output  = %Q{<p>a</p>\n\n<pre class=\"highlight\"><code><span class=\"n\">x</span> <span class=\"o\">=</span> <span class=\"mi\">1</span></code></pre>\n\n<p>b</p>}
 
     index = @wiki.repo.index
     index.add("Bilbo-Baggins.md", content)
@@ -631,25 +631,25 @@ context "Markup" do
 
   test "code blocks with two-space indent" do
     content = "a\n\n```ruby\n  x = 1\n\n  y = 2\n```\n\nb"
-    output  = "<p>a</p>\n\n<pre class=\"highlight\"><span class=\"n\">" +
+    output  = "<p>a</p>\n\n<pre class=\"highlight\"><code><span class=\"n\">" +
         "x</span> <span class=\"o\">=</span> <span class=\"mi\">1" +
         "</span>\n\n<span class=\"n\">y</span> <span class=\"o\">=" +
-        "</span> <span class=\"mi\">2</span>\n</pre>\n\n\n<p>b</p>"
+        "</span> <span class=\"mi\">2</span>\n</code></pre>\n\n\n<p>b</p>"
     compare(content, output)
   end
 
   test "code blocks with one-tab indent" do
     content = "a\n\n```ruby\n\tx = 1\n\n\ty = 2\n```\n\nb"
-    output  = "<p>a</p>\n\n<pre class=\"highlight\"><span class=\"n\">" +
+    output  = "<p>a</p>\n\n<pre class=\"highlight\"><code><span class=\"n\">" +
         "x</span> <span class=\"o\">=</span> <span class=\"mi\">1" +
         "</span>\n\n<span class=\"n\">y</span> <span class=\"o\">=" +
-        "</span> <span class=\"mi\">2</span>\n</pre>\n\n\n<p>b</p>"
+        "</span> <span class=\"mi\">2</span>\n</code></pre>\n\n\n<p>b</p>"
     compare(content, output)
   end
 
   test "code blocks with multibyte characters indent" do
     content = "a\n\n```ruby\ns = 'やくしまるえつこ'\n```\n\nb"
-    output  = %Q{<p>a</p>\n\n<pre class=\"highlight\"><span class=\"n\">s</span> <span class=\"o\">=</span> <span class=\"s1\">'やくしまるえつこ'</span></pre>\n\n<p>b</p>}
+    output  = %Q{<p>a</p>\n\n<pre class=\"highlight\"><code><span class=\"n\">s</span> <span class=\"o\">=</span> <span class=\"s1\">'やくしまるえつこ'</span></code></pre>\n\n<p>b</p>}
     index   = @wiki.repo.index
     index.add("Bilbo-Baggins.md", content)
     index.commit("Add alpha.jpg")
@@ -661,7 +661,7 @@ context "Markup" do
 
   test "code blocks with ascii characters" do
     content = "a\n\n```\n├─foo\n```\n\nb"
-    output  = %(<p>a</p><pre class=\"highlight\">├─foo</pre><p>b</p>)
+    output  = %(<p>a</p><pre class=\"highlight\"><code>├─foo</code></pre><p>b</p>)
     compare(content, output)
   end
 

--- a/test/test_unicode.rb
+++ b/test/test_unicode.rb
@@ -36,7 +36,7 @@ context "Unicode Support" do
   end
 
   def nfd utf8
-    TwitterCldr::Normalization::NFD.normalize utf8
+    TwitterCldr::Normalization.normalize utf8
   end
 
   def check_h1 text, page


### PR DESCRIPTION
- `twitter_cldr` call changed
- Rouge's behavior changed to wrapping all code in `<pre><code>` blocks instead of just `<pre>` blocks.

I don't think the Rouge change is significant, so I changed the tests to match. @sunny @jamieoliver do you see any reason not to accept the `<pre><code>` blocks?
