### PR TITLE
Allow escaping of Macro's with single quote.

### DIFF
--- a/lib/gollum-lib/filter/macro.rb
+++ b/lib/gollum-lib/filter/macro.rb
@@ -10,10 +10,11 @@ class Gollum::Filter::Macro < Gollum::Filter
     arg = %r{(?:#{quoted_arg}|#{unquoted_arg}|#{named_arg})}
     arg_list = %r{(\s*|#{arg}(?:\s*,\s*#{arg})*)}
 
-    data.gsub(/\<\<\s*([A-Z][A-Za-z0-9]*)\s*\(#{arg_list}\)\s*\>\>/) do
-      id = Digest::SHA1.hexdigest($1 + $2)
-      macro = $1
-      argstr = $2
+    data.gsub(/('?)\<\<\s*([A-Z][A-Za-z0-9]*)\s*\(#{arg_list}\)\s*\>\>/) do
+      next CGI.escape_html($&[1..-1]) unless $1.empty?
+      id = Digest::SHA1.hexdigest($2 + $3)
+      macro = $2
+      argstr = $3
       args = []
       opts = {}
       

--- a/test/test_macros.rb
+++ b/test/test_macros.rb
@@ -23,6 +23,12 @@ context "Macros" do
     @teardown.call
   end
 
+
+  test "Macro's are escapable" do
+    @wiki.write_page("MacroEscapeText", :markdown, "'<<AllPages()>>", commit_details)
+    assert_equal "<p>&lt;&lt;AllPages()&gt;&gt;</p>\n", @wiki.pages[0].formatted_data
+  end
+
   test "Missing macro provides missing macro output" do
     @wiki.write_page("NonExistentPage", :markdown, "<<NonExistentMacro()>>", commit_details)
     assert_match /Unknown macro: NonExistentMacro/, @wiki.pages[0].formatted_data


### PR DESCRIPTION
Simple fix to allow espacing of Macros. For example:

```
'<<AllPages()>>
```

Will render:

```
&lt;&lt;AllPages()&gt;&gt;
```

Resolves https://github.com/gollum/gollum/issues/916
