### PR TITLE
Implement Series macro.

### DIFF
--- a/lib/gollum-lib/macro/series.rb
+++ b/lib/gollum-lib/macro/series.rb
@@ -1,0 +1,48 @@
+module Gollum
+  class Macro
+
+    class Series < Gollum::Macro
+      def render(series_prefix = "")
+      	raise "This page's name does not match the prefix '#{series_prefix}'" unless @page.name =~ /^#{series_prefix}/
+      	render_links(*find_series(series_prefix))
+      end
+
+      def render_links(previous_page, next_page)
+      	result = "Previous: <a href=\"#{::File.join(@wiki.base_path,previous_page.escaped_url_path)}\">#{previous_page.name}</a>" if previous_page
+      	result = "#{result}#{result ? ' | ' : ''}Next: <a href=\"#{::File.join(@wiki.base_path,next_page.escaped_url_path)}\">#{next_page.name}</a>" if next_page
+      	wrap_result(result)
+      end
+
+      def wrap_result(result)
+      	result.nil? ? "" : "<div class=\"series\">#{result}</div>"
+      end
+
+      def find_series(series_prefix = "")
+      	dir = @wiki.pages.select {|page| ::File.dirname(page.path) == ::File.dirname(@page.path)}
+      	dir.select! {|page| page.name =~ /\A#{series_prefix}/ } unless series_prefix.empty?
+      	dir.sort_by! {|page| page.name}
+      	self_index = dir.find_index {|page| page.name == @page.name}
+      	if self_index > 0
+          return dir[self_index-1], dir[self_index+1]
+      	else
+          return nil, dir[self_index+1]
+      	end
+      end
+    end
+
+    class SeriesStart < Gollum::Macro::Series
+      def render_links(previous_page, next_page)
+        result = "Next: <a href=\"#{::File.join(@wiki.base_path,next_page.escaped_url_path)}\">#{next_page.name}</a>" if next_page
+        wrap_result(result)
+      end
+    end
+
+    class SeriesEnd < Gollum::Macro::Series
+      def render_links(previous_page, next_page)
+        result = "Previous: <a href=\"#{::File.join(@wiki.base_path,previous_page.escaped_url_path)}\">#{previous_page.name}</a>" if previous_page
+        wrap_result(result)
+      end
+    end
+
+  end
+end

--- a/test/test_macros.rb
+++ b/test/test_macros.rb
@@ -32,6 +32,31 @@ context "Macros" do
     @wiki.write_page("AllPagesMacroPage", :markdown, "<<AllPages()>>", commit_details)
     assert_match /<li>AllPagesMacroPage/, @wiki.pages[0].formatted_data
   end
+
+  test "Series macro displays series links with and without series prefix" do
+    @wiki.write_page("test-series1", :markdown, "<<Series(test)>>", commit_details)
+    testseries1 = @wiki.page("test-series1")
+    @wiki.write_page("test-series2", :markdown, "<<Series(test)>>", commit_details)
+    testseries2 = @wiki.page("test-series2")
+
+    # Now create pages that are alphanumerically earlier, but don't match the 'test' prefix
+    @wiki.write_page("ta-series1", :markdown, "<<Series()>>", commit_details)
+    taseries1 = @wiki.page("ta-series1")
+    @wiki.write_page("ta-series2", :markdown, "<<Series()>>", commit_details)
+    taseries2 = @wiki.page("ta-series2")
+
+    assert_match /Next(.*)test-series2/, testseries1.formatted_data
+    assert_no_match /Previous/, testseries1.formatted_data
+    assert_match /Next(.*)ta-series2/, taseries1.formatted_data
+    assert_match /Previous(.*)ta-series1/, taseries2.formatted_data
+    assert_match /Previous(.*)test-series1/, testseries2.formatted_data
+
+    @wiki.write_page("test-series3", :markdown, "<<SeriesEnd(test)>>", commit_details)
+    testseries3 = @wiki.page("test-series3")
+    @wiki.write_page("test-series4", :markdown, "<<SeriesStart(test)>>", commit_details)
+    testseries4 = @wiki.page("test-series4")
+    assert_no_match /Previous/, testseries4.formatted_data
+  end
   
   test "ListArgs with no args" do
     @wiki.write_page("ListArgsMacroPage", :markdown, "<<ListArgs()>>", commit_details)


### PR DESCRIPTION
Macro described in https://github.com/gollum/gollum/issues/910. It needs tests and probably refactoring -- please have a look.

@SkyCrawl: I hope this is approximately what you had in mind. `<<SeriesStart(prefix)>>` and `<<SeriesEnd(prefix)>>` can be used when there _are_ previous or following pages in the subdirectory, but the user does not want these to be included in the series.
