### PR TITLE
GlobalTOC Macro

### DIFF
--- a/lib/gollum-lib/macro/global_toc.rb
+++ b/lib/gollum-lib/macro/global_toc.rb
@@ -1,0 +1,12 @@
+module Gollum
+  class Macro
+    class GlobalTOC < Gollum::Macro
+      def render(title = "Global Table of Contents")
+        if @wiki.pages.size > 0
+          result = '<ul>' + @wiki.pages.map { |p| "<li><a href=\"#{p.url_path}\">#{p.url_path_display}</a></li>" }.join + '</ul>'
+        end
+        "<div class=\"toc\"><div class=\"toc-title\">#{title}</div>#{result}</div>"
+      end
+    end
+  end
+end

--- a/test/test_macros.rb
+++ b/test/test_macros.rb
@@ -33,6 +33,11 @@ context "Macros" do
     assert_match /<li>AllPagesMacroPage/, @wiki.pages[0].formatted_data
   end
 
+  test "GlobalTOC macro displays global table of contents" do
+    @wiki.write_page("GlobalTOCMacroPage", :markdown, "<<GlobalTOC(Pages in this Wiki)>>", commit_details)
+    assert_match /<div class="toc">(.*)Pages in this Wiki(.*)<li><a href="GlobalTOCMacroPage">GlobalTOCMacroPage/, @wiki.pages[0].formatted_data
+  end
+
   test "Series macro displays series links with and without series prefix" do
     @wiki.write_page("test-series1", :markdown, "<<Series(test)>>", commit_details)
     testseries1 = @wiki.page("test-series1")


### PR DESCRIPTION
See https://github.com/gollum/gollum/issues/921#issuecomment-67859884.

`<<GlobalTOC(Pages in this Wiki)>>` renders as:

![screen shot 2014-12-22 at 20 57 43](https://cloud.githubusercontent.com/assets/147111/5530259/2053ebb2-8a1e-11e4-8af8-bb6f336d2454.png)

Feedback on the layout appreciated -- I used the ordinary TOC's layout so this can easily be included in sidebars, too.
