### PR TITLE
Reverse Creole link parts and refactor reversals. Resolves gollum#78.

### DIFF
--- a/lib/gollum-lib/filter/tags.rb
+++ b/lib/gollum-lib/filter/tags.rb
@@ -207,6 +207,7 @@ class Gollum::Filter::Tags < Gollum::Filter
   # nil if it is not.
   def process_external_link_tag(tag)
     parts = tag.split('|')
+    parts.reverse! if @markup.reverse_links?
     return if parts.size.zero?
     if parts.size == 1
       url = parts[0].strip
@@ -269,7 +270,7 @@ class Gollum::Filter::Tags < Gollum::Filter
   #   if it is not.
   def process_page_link_tag(tag)
     parts = tag.split('|')
-    parts.reverse! if @markup.format == :mediawiki
+    parts.reverse! if @markup.reverse_links?
 
     name, page_name = *parts.compact.map(&:strip)
     cname           = @markup.wiki.page_class.cname(page_name || name)

--- a/lib/gollum-lib/markup.rb
+++ b/lib/gollum-lib/markup.rb
@@ -42,8 +42,9 @@ module Gollum
       # If given a block, that block will be registered with GitHub::Markup to
       # render any matching pages
       def register(ext, name, options = {}, &block)
-        regexp        = options[:regexp] || Regexp.new(ext.to_s)
-        @formats[ext] = { :name => name, :regexp => regexp }
+        @formats[ext] = { :name => name,
+          :regexp => options.fetch(:regexp, Regexp.new(ext.to_s)),
+          :reverse_links => options.fetch(:reverse_links, false) }
       end
     end
 
@@ -80,6 +81,10 @@ module Gollum
       end
       @metadata    = nil
       @to_xml_opts = { :save_with => Nokogiri::XML::Node::SaveOptions::DEFAULT_XHTML ^ 1, :indent => 0, :encoding => 'UTF-8' }
+    end
+
+    def reverse_links?
+      self.class.formats[@format][:reverse_links]
     end
 
     # Render data using default chain in the target format.

--- a/lib/gollum-lib/markups.rb
+++ b/lib/gollum-lib/markups.rb
@@ -5,10 +5,10 @@ module Gollum
     register(:textile,   "Textile")
     register(:rdoc,      "RDoc")
     register(:org,       "Org-mode")
-    register(:creole,    "Creole")
+    register(:creole,    "Creole", :reverse_links => true)
     register(:rest,      "reStructuredText", :regexp => /re?st(\.txt)?/)
     register(:asciidoc,  "AsciiDoc")
-    register(:mediawiki, "MediaWiki", :regexp => /(media)?wiki/)
+    register(:mediawiki, "MediaWiki", :regexp => /(media)?wiki/, :reverse_links => true)
     register(:pod,       "Pod")
     register(:txt,       "Plain Text")
   end


### PR DESCRIPTION
1. Refactor logic for reversing link parts
2. Also reverse Creole links (see https://github.com/gollum/gollum/issues/78)

(Reopened this against `rc`, we should do a minor-level release in the near future anyway.)