### PR TITLE
Revert "Implement syntax highlighting in asciidoc"

### DIFF
--- a/lib/gollum-lib/filter/code.rb
+++ b/lib/gollum-lib/filter/code.rb
@@ -45,18 +45,6 @@ class Gollum::Filter::Code < Gollum::Filter
       "#{$1}#{id}" # print the SHA1 ID with the proper indentation
     end
 
-    if @markup.format == :asciidoc then
-      data.gsub!(/^(\[source,([^\n]*)\]\n)?----\n(.+?)\n----$/m) do
-        lang     = $2.empty? ? nil : $2
-        id       = Digest::SHA1.hexdigest("#{lang}.#{$3}")
-        cached   = @markup.check_cache(:code, id)
-        @map[id] = cached ?
-            { :output => cached } :
-            { :lang => lang, :code => $3, :indent => "" }
-        id
-      end
-    end
-
     data
   end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -11,12 +11,6 @@ require 'mocha/setup'
 require 'minitest/reporters'
 require 'twitter_cldr'
 
-# markup
-begin
-  require 'asciidoctor'
-rescue Exception
-end
-
 # internal
 require File.expand_path('../assertions', __FILE__)
 

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -928,28 +928,10 @@ __TOC__
   end
 
 
-  if defined?(Asciidoctor)
+  if ENV['ASCIIDOC']
     #########################################################################
     # Asciidoc
     #########################################################################
-
-    test "asciidoc syntax highlighting" do
-      input = <<-ASCIIDOC
-[source,python]
-----
-''' A multi-line
-    comment.'''
-def sub_word(mo):
-    ''' Single line comment.'''
-    word = mo.group('word')   # Inline comment
-    if word in keywords[language]:
-        return quote + word + quote
-    else:
-        return word
-----
-      ASCIIDOC
-      compare(input, nil, 'asciidoc', [/\<code\>\<span class=\"s\">''' A multi-line\n    comment.'''\<\/span\>/])
-    end
 
     test "asciidoc header" do
       compare("= Book Title\n\n== Heading", '<div class="sect1"><h2 id="wiki-_heading">Heading<a class="anchor" id="Heading" href="#Heading"></a></h2><div class="sectionbody"></div></div>', 'asciidoc')


### PR DESCRIPTION
This reverts commit 3afe3b47d40a2676e4222132e0db781f15d9344f. These changes are now being applied to the master branch (see https://github.com/gollum/gollum-lib/pull/128).