### PR TITLE
Experimental support for PlantUML (Do not merge).

### DIFF
--- a/lib/gollum-lib/filter/plantuml.rb
+++ b/lib/gollum-lib/filter/plantuml.rb
@@ -1,0 +1,52 @@
+# ~*~ encoding: utf-8 ~*~
+require 'net/http'
+require 'uri'
+require 'open-uri'
+
+# PlantUML Diagrams
+#
+# Render an inline plantuml diagram by generating a PNG image using the
+# plantuml.jar tool.
+#
+class Gollum::Filter::PlantUML < Gollum::Filter
+
+  JAR = "/home/ryujin/plantuml.jar"
+  JAVA = "/home/ryujin/Apps/jdk/bin/java"
+
+  # Extract all sequence diagram blocks into the map and replace with
+  # placeholders.
+  def extract(data)
+    return data if @markup.format == :txt
+    data.gsub(/(@startuml\r?\n.+\r?\n@enduml)/m) do
+      id       = Digest::SHA1.hexdigest($1)
+      @map[id] = { :code => $1 }
+      id
+    end
+  end
+
+  # Process all diagrams from the map and replace the placeholders with
+  # the final HTML.
+  #
+  def process(data)
+    @map.each do |id, spec|
+      data.gsub!(id) do
+        render_plantuml(id, spec[:code])
+      end
+    end
+    data
+  end
+
+  private
+
+  def render_plantuml(id, code)
+    File.open(id, "w") do |file|
+      file << code
+    end
+    system("#{JAVA} -jar #{JAR} #{id}")
+    if $?.success?
+      "<img src=\"#{id}.png\" />"
+    else
+      html_error("failed to generate uml image")
+    end
+  end
+end

--- a/lib/gollum-lib/wiki.rb
+++ b/lib/gollum-lib/wiki.rb
@@ -248,7 +248,7 @@ module Gollum
       @allow_uploads        = options.fetch :allow_uploads, false
       @per_page_uploads     = options.fetch :per_page_uploads, false
       @filter_chain         = options.fetch :filter_chain,
-                                            [:Metadata, :PlainText, :TOC, :RemoteCode, :Code, :Macro, :Sanitize, :WSD, :Tags, :Render]
+                                            [:Metadata, :PlainText, :TOC, :RemoteCode, :Code, :Macro, :Sanitize, :WSD, :PlantUML, :Tags, :Render]
     end
 
     # Public: check whether the wiki's git repo exists on the filesystem.


### PR DESCRIPTION
Incomplete and experimental support PlantUML diagrams:  http://plantuml.sourceforge.net/preprocessing.html. 

Is in "works-for-me" state and this pull request is only to get feedback and request help on some  implementation questions:

  - How to provide gollum with details on where to find the plantuml.jar file?
  - How to provide gollum with the path for the java binary?
  - The plantuml.jar file generates image files (.png). Where should these images be placed?

My ultimate goal is to have gollum (as used in gitlab) accepting PlantUML blocks and replacing them with the generated images locally on the same server without relying on third party services like websequencediagrams. 

As additional benefit PlantUML supports more diagram types
