### PR TITLE
Only use the default email when name is empty

### DIFF
--- a/lib/gollum-lib/committer.rb
+++ b/lib/gollum-lib/committer.rb
@@ -53,8 +53,8 @@ module Gollum
     # Returns a Gollum::Git::Actor.
     def actor
       @actor ||= begin
-        @options[:name]  = @wiki.default_committer_name if @options[:name].to_s.empty?
-        @options[:email] = @wiki.default_committer_email if @options[:email].to_s.empty?
+        @options[:name]  = @wiki.default_committer_name if @options[:name].nil?
+        @options[:email] = @wiki.default_committer_email if @options[:email].nil?
         Gollum::Git::Actor.new(@options[:name], @options[:email])
       end
     end

--- a/lib/gollum-lib/wiki.rb
+++ b/lib/gollum-lib/wiki.rb
@@ -885,8 +885,9 @@ module Gollum
     #
     # Returns the String email address.
     def default_committer_email
-      @default_committer_email ||= \
-        @repo.config['user.email'] || self.class.default_committer_email
+      email = @repo.config['user.email']
+      email = email.delete('<>') if email
+      @default_committer_email ||= email || self.class.default_committer_email
     end
 
     # Gets the commit object for the given ref or sha.

--- a/test/test_committer.rb
+++ b/test/test_committer.rb
@@ -8,21 +8,34 @@ context "Wiki" do
 
   test "normalizes commit hash" do
     commit    = { :message => 'abc' }
-    name      = @wiki.repo.config['user.name'] || @wiki.default_committer_name
-    email     = @wiki.repo.config['user.email'] || @wiki.default_committer_email
+    name      = @wiki.default_committer_name
+    email     = @wiki.default_committer_email
     committer = Gollum::Committer.new(@wiki, commit)
     assert_equal name, committer.actor.name
     assert_equal email, committer.actor.email
 
-    commit[:name]  = 'bob'
+    commit[:name]  = ''
     commit[:email] = ''
+    committer      = Gollum::Committer.new(@wiki, commit)
+    assert_equal '', committer.actor.name
+    assert_equal '', committer.actor.email
+
+    commit[:name]  = nil
+    commit[:email] = nil
+    committer      = Gollum::Committer.new(@wiki, commit)
+    assert_equal name, committer.actor.name
+    assert_equal email, committer.actor.email
+
+    commit[:name]  = 'bob'
+    commit[:email] = nil
     committer      = Gollum::Committer.new(@wiki, commit)
     assert_equal 'bob', committer.actor.name
     assert_equal email, committer.actor.email
 
+    commit[:name]  = nil
     commit[:email] = 'foo@bar.com'
     committer      = Gollum::Committer.new(@wiki, commit)
-    assert_equal 'bob', committer.actor.name
+    assert_equal name, committer.actor.name
     assert_equal 'foo@bar.com', committer.actor.email
   end
 


### PR DESCRIPTION
I've also added angle-bracket email stripping which is also related to the issue. Tests are modified so they pass.

See https://github.com/gollum/gollum/issues/954.
