### PR TITLE
Various improvements to tests, make some more lenient to support jruby

### DIFF
--- a/gollum-lib.gemspec
+++ b/gollum-lib.gemspec
@@ -30,11 +30,11 @@ Gem::Specification.new do |s|
   s.add_dependency 'github-markup', '~> 1.3.3'
 
   s.add_development_dependency 'org-ruby', '~> 0.9.9'
-  s.add_development_dependency 'github-markdown', '~> 0.6.7'
+  s.add_development_dependency 'kramdown', '~> 1.6.0'
   s.add_development_dependency 'RedCloth', '~> 4.2.9'
   s.add_development_dependency 'mocha', '~> 1.1.0'
   s.add_development_dependency 'shoulda', '~> 3.5.0'
-  s.add_development_dependency 'wikicloth', '~> 0.8.1'
+  s.add_development_dependency 'wikicloth', '~> 0.8.3'
   s.add_development_dependency 'rake', '~> 10.4.0'
   s.add_development_dependency 'pry', '~> 0.10.1'
   # required by pry

--- a/lib/gollum-lib/git_access.rb
+++ b/lib/gollum-lib/git_access.rb
@@ -10,7 +10,7 @@ module Gollum
     # page_file_dir - String the directory in which all page files reside
     #
     # Returns this instance.
-    def initialize(path, page_file_dir = nil, bare = false)
+    def initialize(path, page_file_dir = nil, bare = nil)
       @page_file_dir = page_file_dir
       @path          = path
       @repo = Gollum::Git::Repo.new(path, { :is_bare => bare })

--- a/lib/gollum-lib/markups.rb
+++ b/lib/gollum-lib/markups.rb
@@ -1,6 +1,11 @@
 # ~*~ encoding: utf-8 ~*~
 module Gollum
   class Markup
+    
+    GitHub::Markup::Markdown::MARKDOWN_GEMS['kramdown'] = proc { |content|
+        Kramdown::Document.new(content, :auto_ids => false, :input => "markdown").to_html
+    }
+
     register(:markdown,  "Markdown", :regexp => /md|mkdn?|mdown|markdown/)
     register(:textile,   "Textile")
     register(:rdoc,      "RDoc")

--- a/test/filter/test_tags.rb
+++ b/test/filter/test_tags.rb
@@ -23,7 +23,8 @@ context "Gollum::Filter::Tags" do
     markup = Gollum::Markup.new(page)
     filter = Gollum::Filter::Tags.new(markup)
     data_with_placeholders = filter.extract(page.raw_data)
-    assert_max_seconds(2, "tag processing for #{TAGCOUNT} tags") do
+    max_seconds = RUBY_PLATFORM == "java" ? 3 : 2
+    assert_max_seconds(max_seconds, "tag processing for #{TAGCOUNT} tags") do
       data_processed = filter.process(data_with_placeholders)
       assert_equal page_with_many_tags, data_processed
     end

--- a/test/test_macros.rb
+++ b/test/test_macros.rb
@@ -26,7 +26,7 @@ context "Macros" do
 
   test "Macro's are escapable" do
     @wiki.write_page("MacroEscapeText", :markdown, "'<<AllPages()>>", commit_details)
-    assert_equal "<p>&lt;&lt;AllPages()&gt;&gt;</p>\n", @wiki.pages[0].formatted_data
+    assert_match "<p>&lt;&lt;AllPages()&gt;&gt;</p>", @wiki.pages[0].formatted_data
   end
 
   test "Missing macro provides missing macro output" do

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -714,8 +714,8 @@ np.array([[2,2],[1,3]],np.float)
   end
 
   test "embed code page absolute link" do
-    @wiki.write_page("base", :markdown, "a\n!base\b", commit_details)
-    @wiki.write_page("a", :markdown, "a\n```html:/base```\b", commit_details)
+    @wiki.write_page("base", :markdown, "a\n!base", commit_details)
+    @wiki.write_page("a", :markdown, "a\n```html:/base```", commit_details)
 
     page   = @wiki.page("a")
     output = page.formatted_data
@@ -723,8 +723,8 @@ np.array([[2,2],[1,3]],np.float)
   end
 
   test "embed code page relative link" do
-    @wiki.write_page("base", :markdown, "a\n!rel\b", commit_details)
-    @wiki.write_page("a", :markdown, "a\n```html:base```\b", commit_details)
+    @wiki.write_page("base", :markdown, "a\n!rel", commit_details)
+    @wiki.write_page("a", :markdown, "a\n```html:base```", commit_details)
 
     page   = @wiki.page("a")
     output = page.formatted_data
@@ -732,11 +732,11 @@ np.array([[2,2],[1,3]],np.float)
   end
 
   test "code block in unsupported language" do
-    @wiki.write_page("a", :markdown, "a\n```nonexistent\ncode\n```\nb", commit_details)
+    @wiki.write_page("a", :markdown, "a\n\n```nonexistent\ncode\n```", commit_details)
 
     page   = @wiki.page("a")
     output = page.formatted_data
-    assert_html_equal %Q{<p>a\n</p><pre class=\"highlight\"><span class=\"err\">code</span></pre>\nb}, output
+    assert_html_equal %Q{<p>a\n</p><pre class=\"highlight\"><span class=\"err\">code</span></pre>}, output
   end
 
   #########################################################################
@@ -911,7 +911,9 @@ np.array([[2,2],[1,3]],np.float)
   test "identical headers in TOC have unique prefix" do
     content = <<-MARKDOWN
 __TOC__
+
 # Summary
+
 # Summary
     MARKDOWN
 
@@ -922,7 +924,9 @@ __TOC__
   test "anchor names are normalized" do
     content = <<-MARKDOWN
 __TOC__
+
 # Summary '"' stuff
+
 # Summary !@$#%^&*() stuff
     MARKDOWN
 
@@ -933,7 +937,9 @@ __TOC__
   test 'anchor names contain the ancestor' do
     content = <<-MARKDOWN
 __TOC__
+
 # Summary
+
 ## Horse
     MARKDOWN
 


### PR DESCRIPTION
Some minor changes needed to get the tests passing on a local branch running jruby. Moving to kramdown as development dependency, which surprisingly seems to outperform github-markdown (although the ugly configuration bit in `markups.rb` is needed to make kramdown use our flavor of markdown).