### PR TITLE
Update file view tests

### DIFF
--- a/test/file_view/1_file_1_folder.txt
+++ b/test/file_view/1_file_1_folder.txt
@@ -1,7 +1,7 @@
 <ol class="tree">
   <li>
     <label>folder0</label>
-    <input type="checkbox" />
+    <input type="checkbox" checked />
     <ol>
       <li class="file">
         <a href="folder0/0"><span class="icon"></span>0</a>

--- a/test/file_view/1_folder.txt
+++ b/test/file_view/1_folder.txt
@@ -1,7 +1,7 @@
 <ol class="tree">
   <li>
     <label>.</label>
-    <input type="checkbox" />
+    <input type="checkbox" checked />
     <ol>
       <li class="file">
         <a href="folder0"><span class="icon"></span>folder0</a>

--- a/test/file_view/2_files_2_folders.txt
+++ b/test/file_view/2_files_2_folders.txt
@@ -1,7 +1,7 @@
 <ol class="tree">
   <li>
     <label>folder0</label>
-    <input type="checkbox" />
+    <input type="checkbox" checked />
     <ol>
       <li class="file">
         <a href="folder0/0"><span class="icon"></span>0</a>
@@ -10,7 +10,7 @@
   </li>
   <li>
     <label>folder1</label>
-    <input type="checkbox" />
+    <input type="checkbox" checked />
     <ol>
       <li class="file">
         <a href="folder1/1"><span class="icon"></span>1</a>

--- a/test/file_view/2_files_2_folders_1_root.txt
+++ b/test/file_view/2_files_2_folders_1_root.txt
@@ -4,7 +4,7 @@
   </li>
   <li>
     <label>folder0</label>
-    <input type="checkbox" />
+    <input type="checkbox" checked />
     <ol>
       <li class="file">
         <a href="folder0/0"><span class="icon"></span>0</a>
@@ -13,7 +13,7 @@
   </li>
   <li>
     <label>folder1</label>
-    <input type="checkbox" />
+    <input type="checkbox" checked />
     <ol>
       <li class="file">
         <a href="folder1/1"><span class="icon"></span>1</a>

--- a/test/file_view/nested_folders.txt
+++ b/test/file_view/nested_folders.txt
@@ -1,15 +1,15 @@
 <ol class="tree">
   <li>
     <label>folder0</label>
-    <input type="checkbox" />
+    <input type="checkbox" checked />
     <ol>
       <li>
         <label>folder1</label>
-        <input type="checkbox" />
+        <input type="checkbox" checked />
         <ol>
           <li>
             <label>folder2</label>
-            <input type="checkbox" />
+            <input type="checkbox" checked />
             <ol>
               <li class="file">
                 <a href="folder0/folder1/folder2/0"><span class="icon"></span>0</a>
@@ -18,7 +18,7 @@
           </li>
           <li>
             <label>folder3</label>
-            <input type="checkbox" />
+            <input type="checkbox" checked />
             <ol>
               <li class="file">
                 <a href="folder0/folder1/folder3/1"><span class="icon"></span>1</a>
@@ -31,7 +31,7 @@
   </li>
   <li>
     <label>folder4</label>
-    <input type="checkbox" />
+    <input type="checkbox" checked />
     <ol>
       <li class="file">
         <a href="folder4/2"><span class="icon"></span>2</a>

--- a/test/test_file_view.rb
+++ b/test/test_file_view.rb
@@ -70,25 +70,15 @@ def write file, content
   end
 end
 
-def to_html html
-  # Remove blank nodes for proper formatting
-  doc = Nokogiri.XML(html) do |cfg|
-    cfg.default_xml.noblanks
-  end
-
-  # Save as XHTML
-  doc.to_xml({ :save_with => Nokogiri::XML::Node::SaveOptions::DEFAULT_XHTML, :indent => 2, :encoding => 'UTF-8' })
-end
-
 def check name, pages_array
   pages    = FakePages.new pages_array
   expected = read name
-  actual   = to_html view pages
+  actual   = view pages
 
   # Uncomment when updating tests
   # write name, actual
 
-  assert_equal expected, actual
+  assert_html_equal expected, actual
 end
 
 # Test Notes


### PR DESCRIPTION
The nokogiri sanitization previously used to compare the output removed the "checked" attribute of the checkbox fields on MRI, but not on Jruby, causing tests to fail. Luckily we don't need the sanitization since we now have `assert_html_equal`.