### PR TITLE
Fix #153: Default to 'text' lexer for Pygments

### DIFF
--- a/lib/gollum-lib/filter/code.rb
+++ b/lib/gollum-lib/filter/code.rb
@@ -76,8 +76,11 @@ class Gollum::Filter::Code < Gollum::Filter
         if !lang || lang.downcase == 'bash'
           hl_code = "<pre>#{code}</pre>"
         else
+          # Set the default lexer to 'text' to prevent #153
+          lexer = Pygments::Lexer[(lang)] || Pygments::Lexer['text']
+
           # must set startinline to true for php to be highlighted without <?
-          hl_code = Pygments.highlight(code, :lexer => lang, :options => { :encoding => encoding.to_s, :startinline => true })
+          hl_code = lexer.highlight(code, :options => { :encoding => encoding.to_s, :startinline => true })
         end
       else # Rouge
         begin


### PR DESCRIPTION
If pygments.rb does not find a lexer for the provided language in a code block, it will raise an exception. This commit defaults to the 'text' lexer if no lexer can be found.

Dan Allen ([mojavelinux](https://github.com/mojavelinux)) made a similar change in asciidoctor: https://github.com/asciidoctor/asciidoctor/commit/ae103e4d9b25cfe3324e0b55f45c36c11dcc0df8