### PR TITLE
fixed BlobEntry.normalize_dir()

### DIFF
--- a/lib/gollum-lib/blob_entry.rb
+++ b/lib/gollum-lib/blob_entry.rb
@@ -87,6 +87,7 @@ module Gollum
       return '' if dir =~ /^.:\/$/
       if dir
         dir = ::File.expand_path(dir, '/')
+        dir = dir[2..-1] if dir =~ /^[a-zA-Z]:\// # expand_path may add d:/ on windows
         dir = '' if dir == '/'
       end
       dir


### PR DESCRIPTION
On windows, expand_path may add "C:/" to the output. Added line strips
off this case.

Test suite is not running on windows.