### PR TITLE
Fix #154: Code block not correctly escaped when using pygments

### DIFF
--- a/lib/gollum-lib/filter/code.rb
+++ b/lib/gollum-lib/filter/code.rb
@@ -72,16 +72,12 @@ class Gollum::Filter::Code < Gollum::Filter
       encoding = @markup.encoding || 'utf-8'
 
       if defined? Pygments
-        # treat unknown and bash as standard pre tags
-        if !lang || lang.downcase == 'bash'
-          hl_code = "<pre>#{code}</pre>"
-        else
-          # Set the default lexer to 'text' to prevent #153
-          lexer = Pygments::Lexer[(lang)] || Pygments::Lexer['text']
+        # Set the default lexer to 'text' to prevent #153 and #154
+        lang = lang || 'text'
+        lexer = Pygments::Lexer[(lang)] || Pygments::Lexer['text']
 
-          # must set startinline to true for php to be highlighted without <?
-          hl_code = lexer.highlight(code, :options => { :encoding => encoding.to_s, :startinline => true })
-        end
+        # must set startinline to true for php to be highlighted without <?
+        hl_code = lexer.highlight(code, :options => { :encoding => encoding.to_s, :startinline => true })
       else # Rouge
         begin
           # if `lang` was not defined then assume plaintext


### PR DESCRIPTION
For some reason code blocks used to default to simple `<pre>` tags when the specified language was nil or bash. This caused html tags in the code block to not get escaped since they were never passed
to pygments.

This fix defaults to the 'text' language if none is specified and allows pygments to render bash code blocks since it supports it.