### PR TITLE
fix for toc list levels

### DIFF
--- a/lib/gollum-lib/filter/toc.rb
+++ b/lib/gollum-lib/filter/toc.rb
@@ -79,25 +79,28 @@ class Gollum::Filter::TOC < Gollum::Filter
   # is a link to the given anchor name
   def add_entry_to_toc(header, name)
     @toc ||= Nokogiri::XML::DocumentFragment.parse('<div class="toc"><div class="toc-title">Table of Contents</div></div>')
-    tail ||= @toc.child
-    tail_level ||= 0
+    @tail ||= @toc.child
+    @tail_level ||= 0
 
     level = header.name.gsub(/[hH]/, '').to_i
 
-    while tail_level < level
-      node = Nokogiri::XML::Node.new('ul', @doc)
-      tail = tail.add_child(node)
-      tail_level += 1
+    if @tail_level < level
+      while @tail_level < level
+        list = Nokogiri::XML::Node.new('ul', @doc)
+        @tail.add_child(list)
+        @tail = list.add_child(Nokogiri::XML::Node.new('li', @doc))
+        @tail_level += 1
+      end
+    else
+      while @tail_level > level
+        @tail = @tail.parent.parent
+        @tail_level -= 1
+      end
+      @tail = @tail.parent.add_child(Nokogiri::XML::Node.new('li', @doc))
     end
-    
-    while tail_level > level
-      tail = tail.parent
-      tail_level -= 1
-    end
-    node = Nokogiri::XML::Node.new('li', @doc)
+
     # % -> %25 so anchors work on Firefox. See issue #475
-    node.add_child(%Q{<a href="##{name}">#{header.content}</a>})
-    tail.add_child(node)
+    @tail.add_child(%Q{<a href="##{name}">#{header.content}</a>})
   end
 
   # Increments the number of anchors with the given name


### PR DESCRIPTION
I recognized, when I overwrite your toc from using ul to ol, that the list levels are kind of a little messed up.
I fixed that for me on ol - but I think perhaps you want to have it on the ul, too. With this it's easy to perhaps add an option, to use ol instead of ul. Only line 89 would have to be changed for that.