### PR TITLE
Remove hard-coded reference to master in `#preview_page`

### DIFF
--- a/lib/gollum-lib/wiki.rb
+++ b/lib/gollum-lib/wiki.rb
@@ -310,7 +310,7 @@ module Gollum
       name = @page_class.cname(name) + '.' + ext
       blob = OpenStruct.new(:name => name, :data => data, :is_symlink => false)
       page.populate(blob)
-      page.version = @access.commit('master')
+      page.version = @access.commit(@ref)
       page
     end
 


### PR DESCRIPTION
When previewing a page, the commit should be set to the value in
`@ref`, not systematically to `master`.