### PR TITLE
Allow setting max header level in TOC

### DIFF
--- a/lib/gollum-lib/filter/tags.rb
+++ b/lib/gollum-lib/filter/tags.rb
@@ -73,7 +73,7 @@ class Gollum::Filter::Tags < Gollum::Filter
   #
   # Returns the String HTML version of the tag.
   def process_tag(tag)
-    if tag =~ /^_TOC_$/
+    if tag =~ /^_TOC_/
       %{[[#{tag}]]}
     elsif tag =~ /^_$/
       %{<div class="clearfloats"></div>}

--- a/lib/gollum-lib/filter/toc.rb
+++ b/lib/gollum-lib/filter/toc.rb
@@ -34,15 +34,11 @@ class Gollum::Filter::TOC < Gollum::Filter
 
     @markup.toc = toc_str
 
-    data.gsub(/\[\[_TOC_(.*?)\]\]/) do
+    data.gsub!(/\[\[_TOC_(.*?)\]\]/) do
       levels = nil
-
-      opts = Regexp.last_match[1].split('|')[1..-1] || []
-      opts.each do |attr|
-        parts = attr.split('=').map { |x| x.strip }
-        if parts[0] == 'levels'
-          levels = Integer(parts[1])
-        end
+      levels_match = Regexp.last_match[1].match /\|\s*levels\s*=\s*(\d+)/
+      if levels_match
+        levels = levels_match[1].to_i
       end
 
       if levels.nil? || toc_str.empty?
@@ -58,6 +54,8 @@ class Gollum::Filter::TOC < Gollum::Filter
         toc_clone.to_xml(@markup.to_xml_opts)
       end
     end
+
+    data
   end
 
   private

--- a/lib/gollum-lib/filter/toc.rb
+++ b/lib/gollum-lib/filter/toc.rb
@@ -7,12 +7,13 @@ class Gollum::Filter::TOC < Gollum::Filter
   def process(data)
 
     @doc               = Nokogiri::HTML::DocumentFragment.parse(data)
-    @toc               = nil
+    @toc_doc           = nil
     @anchor_names      = {}
     @current_ancestors = []
 
+    toc_str            = ''
     if @markup.sub_page && @markup.parent_page
-      @toc = @markup.parent_page.toc_data
+      toc_str = @markup.parent_page.toc_data
     else
       @doc.css('h1,h2,h3,h4,h5,h6').each_with_index do |header, i|
         next if header.content.empty?
@@ -24,15 +25,38 @@ class Gollum::Filter::TOC < Gollum::Filter
         add_anchor_to_header header, anchor_name
         add_entry_to_toc     header, anchor_name
       end
+      if not @toc_doc.nil?
+        toc_str = @toc_doc.to_xml(@markup.to_xml_opts)
+      end
 
-      @toc  = @toc.to_xml(@markup.to_xml_opts) if @toc != nil
       data  = @doc.to_xml(@markup.to_xml_opts)
-      
     end
- 
-    @markup.toc = @toc
-    data.gsub("[[_TOC_]]") do
-      @toc.nil? ? '' : @toc
+
+    @markup.toc = toc_str
+
+    data.gsub(/\[\[_TOC_(.*?)\]\]/) do
+      levels = nil
+
+      opts = Regexp.last_match[1].split('|')[1..-1] || []
+      opts.each do |attr|
+        parts = attr.split('=').map { |x| x.strip }
+        if parts[0] == 'levels'
+          levels = Integer(parts[1])
+        end
+      end
+
+      if levels.nil? || toc_str.empty?
+        toc_str
+      else
+        @toc_doc ||= Nokogiri::HTML::DocumentFragment.parse(toc_str)
+        toc_clone = @toc_doc.clone
+        toc_clone.traverse do |e|
+          if e.name == 'ul' and e.ancestors.length > levels + 1
+            e.remove
+          end
+        end
+        toc_clone.to_xml(@markup.to_xml_opts)
+      end
     end
   end
 
@@ -78,8 +102,8 @@ class Gollum::Filter::TOC < Gollum::Filter
   # Adds an entry to the TOC for the given header.  The generated entry
   # is a link to the given anchor name
   def add_entry_to_toc(header, name)
-    @toc ||= Nokogiri::XML::DocumentFragment.parse('<div class="toc"><div class="toc-title">Table of Contents</div></div>')
-    tail ||= @toc.child
+    @toc_doc ||= Nokogiri::XML::DocumentFragment.parse('<div class="toc"><div class="toc-title">Table of Contents</div></div>')
+    tail ||= @toc_doc.child
     tail_level ||= 0
 
     level = header.name.gsub(/[hH]/, '').to_i

--- a/test/test_wiki.rb
+++ b/test/test_wiki.rb
@@ -142,7 +142,7 @@ context "Wiki TOC" do
 
   test "empty TOC" do
     page = @wiki.preview_page("Test", "[[_TOC_]] [[_TOC_|levels = 2]] Bilbo", :markdown)
-    assert_html_equal "Bilbo", page.formatted_data
+    assert_html_equal "<p>Bilbo</p>", page.formatted_data
     assert_empty page.toc_data
   end
 


### PR DESCRIPTION
Hi! This PR implements gollum/gollum#650.
`levels` attr is added to the `[[_TOC_]]` tag. Its value determines the maximum header level to appear in TOC.

For this to work with subpages I had to re-parse generated TOC html which is inelegant but I guess it is minimally invasive.

Also some empty `<ul>` tags are left in HTML but I did not bother fixing it because they are not rendered in browser and anyway the problem should go away after #176 is merged.