### PR TITLE
Add test-unit development dependency. Closes #178.

### DIFF
--- a/gemspec.rb
+++ b/gemspec.rb
@@ -42,6 +42,7 @@ def specification(version, default_adapter, platform = nil)
     # required by pry
     s.add_development_dependency 'rb-readline', '~> 0.5.1'
     # updating minitest-reporters requires a new minitest which fails with gollum's tests.
+    s.add_development_dependency 'test-unit', '~> 3.1.5'
     s.add_development_dependency 'minitest-reporters', '~> 0.14.16'
     s.add_development_dependency 'nokogiri-diff', '~> 0.2.0'
     # required by guard


### PR DESCRIPTION
As suggested in #178 - added the `test-unit` dependency, in version 3.1.5, at the suggested line.

I checked that it worked on every supported MRI point version (1.9.3, 2.0, 2.1, 2.2).