### PR TITLE
Simplify revert

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,2 @@
 source 'https://rubygems.org'
-
 gemspec :name => RUBY_PLATFORM == 'java' ? 'gollum-lib_java' : 'gollum-lib'

--- a/test/test_wiki.rb
+++ b/test/test_wiki.rb
@@ -86,19 +86,6 @@ context "Wiki" do
     end
   end
 
-  test "gets reverse diff" do
-    diff = @wiki.full_reverse_diff('a8ad3c09dd842a3517085bfadd37718856dee813')
-    assert_match "a/Mordor/_Sidebar.md", diff
-    assert_match "a/_Sidebar.md", diff
-  end
-
-  test "gets reverse diff for a page" do
-    diff  = @wiki.full_reverse_diff_for('_Sidebar.md', 'a8ad3c09dd842a3517085bfadd37718856dee813')
-    regex = /a\/Mordor\/\_Sidebar\.md/
-    assert_match "a/_Sidebar.md", diff
-    assert_no_match regex, diff
-  end
-
   test "gets scoped page from specified directory" do
     @path = cloned_testpath('examples/lotr.git')
     begin


### PR DESCRIPTION
Simplify the implementation of Wiki#revert_page by abstracting low-level grit calls to the grit adapter (gollum/grit_adapter#14). I've manually tested that this branch with the corresponding branch of grit_adapter behaves the same as master, but would appreciate if someone else could verify this (since the revert tests don't work with grit).