### PR TITLE
Fixes #158

### DIFF
--- a/test/test_hook.rb
+++ b/test/test_hook.rb
@@ -90,7 +90,7 @@ context 'Pushing and pulling' do
     @origin.write_page("Gollum2", :markdown, "New content2", {:message => "Wrote second test page"})
     @clone.repo.git.pull("origin", "master")
     # Rugged does not support high-level pull yet, so pull is implemented as a merge. Hence need to check for merge commit on rugged adapter.
-    assert_equal ["Wrote second test page", "Merged branch refs/heads/master of origin."].include?(@clone.repo.commits.first.message), true
+    assert_equal ["Wrote second test page", "Merged branch refs/heads/master of origin."].include?(@clone.repo.head.commit.message), true
   end
   
   teardown do


### PR DESCRIPTION
Adds sleep in test_push_and_pull to ensure ordering of commits.

On Ruby 2.2.4, this test was failing for me.  Looking at the clone git repo from the command line the ordering of commits was correct and included the second commit, however inspecting with byebug had the commits in the wrong order.  I'm pretty sure this is due to them both having the same timestamp.  Looking into the Commit class in gitlab-grit shows that it uses rev_list when calculating the array of commits, and according to https://git-scm.com/docs/git-rev-list: 

```
git-rev-list - Lists commit objects in reverse chronological order
```

The simplest fix is to include a one second sleep between the commits, which I have done here and now all tests are passing.  It would be possible to properly order the commits when the timestamp is equal, but that would require modifying gitlab-grit and my goal here was simply to get all tests passing in gollum-lib.