### PR TITLE
GlobalTOC: Fix relpath issue when navigating in a subdirectory (2)

### DIFF
--- a/lib/gollum-lib/macro/global_toc.rb
+++ b/lib/gollum-lib/macro/global_toc.rb
@@ -3,7 +3,7 @@ module Gollum
     class GlobalTOC < Gollum::Macro
       def render(title = "Global Table of Contents")
         if @wiki.pages.size > 0
-          result = '<ul>' + @wiki.pages.map { |p| "<li><a href=\"#{p.url_path}\">#{p.url_path_display}</a></li>" }.join + '</ul>'
+          result = '<ul>' + @wiki.pages.map { |p| "<li><a href=\"/#{p.url_path}\">#{p.url_path_display}</a></li>" }.join + '</ul>'
         end
         "<div class=\"toc\"><div class=\"toc-title\">#{title}</div>#{result}</div>"
       end

--- a/test/test_macros.rb
+++ b/test/test_macros.rb
@@ -41,7 +41,7 @@ context "Macros" do
 
   test "GlobalTOC macro displays global table of contents" do
     @wiki.write_page("GlobalTOCMacroPage", :markdown, "<<GlobalTOC(Pages in this Wiki)>>", commit_details)
-    assert_match /<div class="toc">(.*)Pages in this Wiki(.*)<li><a href="GlobalTOCMacroPage">GlobalTOCMacroPage/, @wiki.pages[0].formatted_data
+    assert_match /<div class="toc">(.*)Pages in this Wiki(.*)<li><a href="\/GlobalTOCMacroPage">GlobalTOCMacroPage/, @wiki.pages[0].formatted_data
   end
 
   test "Series macro displays series links with and without series prefix" do


### PR DESCRIPTION
The GlobalTOC macro uses relative paths to navigate. This causes an
issue if the user is located in a subdirectory, as this path will be
added to the current location and point to an invalide page.

A simple fix is to use absolute paths by prefixing with '/'.