### PR TITLE
Fix TOC with level behavior after #176

### DIFF
--- a/lib/gollum-lib/filter/toc.rb
+++ b/lib/gollum-lib/filter/toc.rb
@@ -47,7 +47,7 @@ class Gollum::Filter::TOC < Gollum::Filter
         @toc_doc ||= Nokogiri::HTML::DocumentFragment.parse(toc_str)
         toc_clone = @toc_doc.clone
         toc_clone.traverse do |e|
-          if e.name == 'ul' and e.ancestors.length > levels + 1
+          if e.name == 'ul' and e.ancestors('ul').length > levels - 1
             e.remove
           end
         end

--- a/test/test_wiki.rb
+++ b/test/test_wiki.rb
@@ -181,14 +181,22 @@ context "Wiki TOC" do
     HTML
     assert_html_equal toc_formatted_level0 + formatted, page_level0.formatted_data
 
+    page_level1 = @wiki.preview_page("Test", "[[_TOC_ | levels=1]] \n\n" + content, :markdown)
+    toc_formatted_level1 = <<-HTML
+<p><div class="toc">
+<div class="toc-title">Table of Contents</div>
+<ul><li><a href="#ecthelion">Ecthelion</a></li></ul>
+</div></p>
+    HTML
+    assert_html_equal toc_formatted_level1 + formatted, page_level1.formatted_data
+
     page_level2 = @wiki.preview_page("Test", "[[_TOC_ |levels = 2]] \n\n" + content, :markdown)
     toc_formatted_level2 = <<-HTML
 <p><div class="toc">
 <div class="toc-title">Table of Contents</div>
-<ul><li><a href="#ecthelion">Ecthelion</a></li></ul>
-<ul><ul><li><a href="#ecthelion_denethor">Denethor</a></li></ul></ul>
-<ul><ul></ul></ul>
-<ul><ul></ul></ul>
+<ul><li><a href="#ecthelion">Ecthelion</a>
+<ul><li><a href="#ecthelion_denethor">Denethor</a></li></ul>
+</li></ul>
 </div></p>
     HTML
     assert_html_equal toc_formatted_level2 + formatted, page_level2.formatted_data
@@ -199,10 +207,17 @@ context "Wiki TOC" do
     toc_formatted_full = <<-HTML
 <p><div class="toc">
 <div class="toc-title">Table of Contents</div>
-<ul><li><a href="#ecthelion">Ecthelion</a></li></ul>
-<ul><ul><li><a href="#ecthelion_denethor">Denethor</a></li></ul></ul>
-<ul><ul><ul><li><a href="#ecthelion_denethor_boromir">Boromir</a></li></ul></ul></ul>
-<ul><ul><ul><li><a href="#ecthelion_denethor_faramir">Faramir</a></li></ul></ul></ul>
+<ul>
+  <li>
+    <a href="#ecthelion">Ecthelion</a>
+    <ul>
+      <li><a href="#ecthelion_denethor">Denethor</a>
+    <ul>
+      <li><a href="#ecthelion_denethor_boromir">Boromir</a></li>
+      <li><a href="#ecthelion_denethor_faramir">Faramir</a></li>
+    </ul>
+  </li></ul>
+</li></ul>
 </div></p>
     HTML
     assert_html_equal toc_formatted_full + formatted, page_level3.formatted_data


### PR DESCRIPTION
Merging #176 apparently caused the new behavior introduced by #183 to fail. #176 cleaned up the TOC html, but the new max-levels functionality was expecting the less clean html. In particular, [this check](https://github.com/gollum/gollum-lib/blob/master/lib/gollum-lib/filter/toc.rb#L50) was no longer accurate: #176 added `<li>` tags surrounding the `<ul>` so that `ancestors.length` became larger.

I've attempted to solve the issue by looking at *only* the ancestors that are `<ul>`'s to ascertain the level of a heading. I also had to update the test html.

@ztlpn: would appreciate a quick glance at my fix to `toc.rb` if you could spare the time.