### PR TITLE
Put back MRI 2.2 and 2.3 in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ rvm:
   - 2.0.0
   - 2.1.0
   - 2.1.1
-  # - 2.2.1
-  # - 2.3.0
+  - 2.2.1
+  - 2.3.0
   - jruby-19mode
 before_install:
  - sudo apt-get update


### PR DESCRIPTION
The underlying issue that had led to the deactivation
of these versions of Ruby was Issue #158, which was solved
by PR #193.