### PR TITLE
Support utf-8 page names unless using Grit

### DIFF
--- a/lib/gollum-lib/committer.rb
+++ b/lib/gollum-lib/committer.rb
@@ -118,7 +118,7 @@ module Gollum
         end
       end
 
-      fullpath = fullpath.force_encoding('ascii-8bit') if fullpath.respond_to?(:force_encoding)
+      encode! fullpath
 
       begin
         data = @wiki.normalize(data)
@@ -151,7 +151,7 @@ module Gollum
               ::File.join(dir, @wiki.page_file_name(name, format))
             end
 
-        path = path.force_encoding('ascii-8bit') if path.respond_to?(:force_encoding)
+        encode! path
 
         Dir.chdir(::File.join(@wiki.repo.path, '..')) do
           if file_path_scheduled_for_deletion?(index.tree, path)
@@ -236,8 +236,17 @@ module Gollum
 
     # Proxies methods t
     def method_missing(name, *args)
-      args.map! { |item| item.respond_to?(:force_encoding) ? item.force_encoding('ascii-8bit') : item }
+      args.map! { |item| encode! item }
       index.send(name, *args)
+    end
+
+    def encode!(target)
+      if defined?(Gollum::GIT_ADAPTER) && Gollum::GIT_ADAPTER != 'grit'
+        # Do not transliterate utf-8 url's unless using Grit
+        target
+      elsif target.respond_to?(:force_encoding)
+        target.force_encoding('ascii-8bit')
+      end
     end
   end
 end


### PR DESCRIPTION
### Problem

It needs that apps using gollum-lib override String class to support utf-8 page names.