### PR TITLE
Configure plantuml filter via environment variable.

### DIFF
--- a/lib/gollum-lib/filter/plantuml.rb
+++ b/lib/gollum-lib/filter/plantuml.rb
@@ -37,7 +37,7 @@ require 'zlib'
 #
 class Gollum::Filter::PlantUML < Gollum::Filter
 
-  DEFAULT_URL = "http://localhost:8080/plantuml/png"
+  DEFAULT_URL = ENV["PLANTUML_URL"] || "http://localhost:8080/plantuml/png"
 
   # Configuration class used to change the behaviour of the PlatnUML filter.
   #


### PR DESCRIPTION
Modify plantuml filter to support configuration via environment variables. This is useful when running gollum from the command line.

    export PLANTUML_URL="https://my-plantuml-server:9091/plantuml/png"
    gollum

