### PR TITLE
Allow mark HTML tag

### DIFF
--- a/lib/gollum-lib/sanitization.rb
+++ b/lib/gollum-lib/sanitization.rb
@@ -12,7 +12,7 @@ module Gollum
         'code', 'col', 'colgroup', 'dd', 'del', 'dfn', 'dir',
         'div', 'dl', 'dt', 'em', 'fieldset', 'font', 'form', 'h1',
         'h2', 'h3', 'h4', 'h5', 'h6', 'hr', 'i', 'img', 'input',
-        'ins', 'kbd', 'label', 'legend', 'li', 'map', 'menu',
+        'ins', 'kbd', 'label', 'legend', 'li', 'map', 'mark', 'menu',
         'ol', 'optgroup', 'option', 'p', 'pre', 'q', 's', 'samp',
         'select', 'small', 'span', 'strike', 'strong', 'sub',
         'sup', 'table', 'tbody', 'td', 'textarea', 'tfoot', 'th',


### PR DESCRIPTION
This tiny commit adds the `<mark>` tag to the whitelist.

`<mark>` is part of HTML5 and used to highlight a text passage marker-style. I find it very useful in wikis and since you can't really do anything evil or dangerous with it, why not whitelisting it?