### PR TITLE
use rouge 2.0 and manual wrapping

### DIFF
--- a/gemspec.rb
+++ b/gemspec.rb
@@ -25,7 +25,7 @@ def specification(version, default_adapter, platform = nil)
     s.extra_rdoc_files = %w(README.md LICENSE)
 
     s.add_dependency *default_adapter
-    s.add_dependency 'rouge', '~> 1.10'
+    s.add_dependency 'rouge', '~> 2.0'
     s.add_dependency 'nokogiri', '~> 1.6.4'
     s.add_dependency 'stringex', '~> 2.5.1'
     s.add_dependency 'sanitize', '~> 2.1.0'

--- a/lib/gollum-lib/filter/code.rb
+++ b/lib/gollum-lib/filter/code.rb
@@ -82,16 +82,15 @@ class Gollum::Filter::Code < Gollum::Filter
         hl_code = lexer.highlight(code, :options => { :encoding => encoding.to_s, :startinline => true })
       else # Rouge
         begin
+          # if `lang` was not defined then assume plaintext
           lexer = Rouge::Lexer.find_fancy(lang || 'plaintext')
           formatter = Rouge::Formatters::HTML.new
+          wrap_template = '<pre class="highlight"><code>%s</code></pre>'
 
-          # if `lang` was not defined then assume plaintext
-          # if `lang` is defined but cannot be found then wrap it and escape it
+          # if `lang` is defined but cannot be found then wrap it with an error
           if lexer.nil?
             lexer = Rouge::Lexers::PlainText
             wrap_template = '<pre class="highlight"><span class="err">%s</span></pre>'
-          else
-            wrap_template = '<pre class="highlight"><code>%s</code></pre>'
           end
 
           formatted = formatter.format(lexer.lex(code))

--- a/lib/gollum-lib/filter/code.rb
+++ b/lib/gollum-lib/filter/code.rb
@@ -82,17 +82,21 @@ class Gollum::Filter::Code < Gollum::Filter
         hl_code = lexer.highlight(code, :options => { :encoding => encoding.to_s, :startinline => true })
       else # Rouge
         begin
+          lexer = Rouge::Lexer.find_fancy(lang || 'plaintext')
+          formatter = Rouge::Formatters::HTML.new
+
           # if `lang` was not defined then assume plaintext
           # if `lang` is defined but cannot be found then wrap it and escape it
-          lang ||= 'plaintext'
-          if Rouge::Lexer.find(lang).nil?
-            lexer     = Rouge::Lexers::PlainText.new
-            formatter = Rouge::Formatters::HTML.new(:wrap => false)
-            hl_code   = formatter.format(lexer.lex(code))
-            hl_code   = "<pre class='highlight'><span class='err'>#{CGI.escapeHTML(hl_code)}</span></pre>"
+          if lexer.nil?
+            lexer = Rouge::Lexers::PlainText
+            wrap_template = '<pre class="highlight"><span class="err">%s</span></pre>'
           else
-            hl_code = Rouge.highlight(code, lang, 'html')
+            wrap_template = '<pre class="highlight"><code>%s</code></pre>'
           end
+
+          formatted = formatter.format(lexer.lex(code))
+
+          hl_code = Kernel.sprintf(wrap_template, formatted)
         rescue
           hl_code = code
         end


### PR DESCRIPTION
This PR uses rouge 2.0, where `Rouge::Formatters::HTML` no longer automatically inserts any tags. This makes it a bit easier to use the formatting infrastructure and not work around its automatic wrapping.