### PR TITLE
Speed up page loading via caching name canonicalization

### DIFF
--- a/lib/gollum-lib/file.rb
+++ b/lib/gollum-lib/file.rb
@@ -140,7 +140,9 @@ module Gollum
       map     = @wiki.tree_map_for(version)
       commit  = version.is_a?(Gollum::Git::Commit) ? version : @wiki.commit_for(version)
 
-      if (result = map.detect { |entry| entry.path.downcase == checked })
+      file_map = @wiki.tree_file_map_for(version)
+      if file_map.has_key?(checked)
+        result = file_map[checked]
         @path    = name
         @version = commit
 

--- a/lib/gollum-lib/page.rb
+++ b/lib/gollum-lib/page.rb
@@ -353,9 +353,13 @@ module Gollum
     #
     # Returns the String canonical name.
     def self.cname(name, char_white_sub = '-', char_other_sub = '-')
-      name.respond_to?(:gsub) ?
-          name.gsub(%r(\s), char_white_sub).gsub(%r([<>+]), char_other_sub) :
-          ''
+      if name.respond_to?(:tr) and char_white_sub.size == 1 and char_other_sub.size == 1
+          name.tr( " \t\r\n\f" '<>+', ('\\'+char_white_sub)*5 + ('\\'+char_other_sub)*3 )
+      else
+          name.respond_to?(:gsub) ?
+              name.gsub(%r(\s), char_white_sub).gsub(%r([<>+]), char_other_sub) :
+              ''
+      end
     end
 
     # Convert a format Symbol into an extension String.

--- a/lib/gollum-lib/wiki.rb
+++ b/lib/gollum-lib/wiki.rb
@@ -252,6 +252,8 @@ module Gollum
       @filter_chain         = options.fetch :filter_chain,
                                             [:Metadata, :PlainText, :TOC, :RemoteCode, :Code, :Macro, :Emoji, :Sanitize, :WSD, :PlantUML, :Tags, :Render]
       @filter_chain.delete(:Emoji) unless options.fetch :emoji, false
+
+      clear
     end
 
     # Public: check whether the wiki's git repo exists on the filesystem.
@@ -694,6 +696,7 @@ module Gollum
     # Returns nothing.
     def clear_cache
       @access.refresh
+      clear
     end
 
     # Public: Creates a Sanitize instance using the Wiki's sanitization
@@ -832,6 +835,42 @@ module Gollum
     # named after the page they were uploaded to.
     attr_reader :per_page_uploads
 
+    # Public: Clears all of the cached data that this Wiki is tracking.
+    #
+    # Returns nothing.
+    def clear
+      @tree_page_map = {}
+    end
+
+    # Attempts to get the given data from a cache.  If it doesn't exist, it'll
+    # pass the results of the yielded block to the cache for future accesses.
+    #
+    # name - The cache prefix used in building the full cache key.
+    # key  - The unique cache key suffix, usually a String Git SHA.
+    #
+    # Yields a block to pass to the cache.
+    # Returns the cached result.
+    def get_cache(name, key)
+      cache = instance_variable_get("@#{name}_map")
+      value = cache[key]
+      if value.nil? && block_given?
+        set_cache(name, key, value = yield)
+      end
+      value == :_nil ? nil : value
+    end
+
+    # Writes some data to the internal cache.
+    #
+    # name  - The cache prefix used in building the full cache key.
+    # key   - The unique cache key suffix, usually a String Git SHA.
+    # value - The value to write to the cache.
+    #
+    # Returns nothing.
+    def set_cache(name, key, value)
+      cache      = instance_variable_get("@#{name}_map")
+      cache[key] = value || :_nil
+    end
+
     # Normalize the data.
     #
     # data - The String data to be normalized.
@@ -957,6 +996,47 @@ module Gollum
       end
     rescue Gollum::Git::NoSuchShaFound
       []
+    end
+
+    # Returns a { canonical_name => BlobEntry } map for a given SHA
+    # Canonicalization happens through the page_class.normalized_names method
+    #
+    # ref - A String ref that is either a commit SHA or references one.
+    # include_dir - Boolean, if true, include the entry's directory in the Hash key
+    #
+    # Returns a Hash of String => BlobEntry instances
+    def tree_page_map_for(ref, include_dir=false)
+      if (sha = @access.ref_to_sha(ref))
+        get_cache(:tree_page, [sha,!!include_dir] ) { tree_page_map_for!(ref, include_dir) }
+      else
+        {}
+      end
+    rescue Gollum::Git::NoSuchShaFound
+      {}
+    end
+
+    # Generates a { canonical_name => BlobEntry } map for a given SHA
+    # Canonicalization happens through the page_class.normalized_names method
+    # Will cache the value of the map
+    #
+    # ref - A String ref that is either a commit SHA or references one.
+    # include_dir - Boolean, if true, include the entry's directory in the Hash key
+    #
+    # Returns a Hash of String => BlobEntry instances or nil
+    def tree_page_map_for!(ref, include_dir=false)
+      map = tree_map_for(ref.to_s)
+      return nil if !map
+
+      page_hash = Hash.new
+      map.each do |entry|
+        next if entry.name.to_s.empty?
+        path = include_dir ? ::File.join(entry.dir, entry.name) : entry.name
+	page_class.normalized_names(path, ws_subs).each do |pagename|
+          page_hash[ pagename ] = entry
+        end
+      end
+
+      page_hash.empty? ? nil : page_hash
     end
 
     def inspect


### PR DESCRIPTION
Page loading on our Gollum wiki is very slow. In part that's due to the large number of page and having a fair number of links per page. 

Investigation with various profiling utilities  (e.g. ruby-prof) indicated that the majority of the time was spent in text processing, particularly in page and file name canonicalization. The same text normalization steps were being done for every page/file in the repository, for each link being rendered. 

To fix this, I've taken the caching scheme from the GitAccess object and added it to Wiki object. In the Wiki object the appropriately pre-processed page and file names are now cached, on a per-SHA1 basis. This pre-processed data gets stored in a Hash, so the rendering of each link after the very first should be sped up significantly.

On my local machine, for my particular wiki of interest, launching Gollum, rendering 4 example pages and exiting out takes a total of ~22 CPU seconds ("user" time) with current master. Using the changes in this pull request, this is reduced to ~1.9 CPU seconds (a 10-fold speedup).

---

One issue I'm still a bit hazy on is the memory impact on long-running processes. I think I have set things up such that the cached values in the Wiki object get cleared out occasionally, but I'm not confident enough in how long-running Gollum systems work to say that the new scheme won't slowly accumulate memory as additional SHA1s get added.
