### PR TITLE
fix bug:can not support files with non-ascii name

### DIFF
--- a/gemspec.rb
+++ b/gemspec.rb
@@ -8,7 +8,7 @@ def specification(version, default_adapter, platform = nil)
     s.name              = 'gollum-lib'
     s.version           = version
     s.platform          = platform if platform
-    s.date              = '2016-11-18'
+    s.date              = '2016-12-11'
     s.rubyforge_project = 'gollum-lib'
     s.license           = 'MIT'
 

--- a/lib/gollum-lib/file.rb
+++ b/lib/gollum-lib/file.rb
@@ -140,7 +140,7 @@ module Gollum
       map     = @wiki.tree_map_for(version)
       commit  = version.is_a?(Gollum::Git::Commit) ? version : @wiki.commit_for(version)
 
-      if (result = map.detect { |entry| entry.path.downcase == checked })
+      if (result = map.detect { |entry| entry.path.force_encoding('utf-8').downcase == checked } })
         @path    = name
         @version = commit
 

--- a/lib/gollum-lib/file.rb
+++ b/lib/gollum-lib/file.rb
@@ -140,7 +140,7 @@ module Gollum
       map     = @wiki.tree_map_for(version)
       commit  = version.is_a?(Gollum::Git::Commit) ? version : @wiki.commit_for(version)
 
-      if (result = map.detect { |entry| entry.path.force_encoding('utf-8').downcase == checked } })
+      if (result = map.detect { |entry| entry.path.force_encoding('utf-8').downcase == checked } )
         @path    = name
         @version = commit
 

--- a/lib/gollum-lib/page.rb
+++ b/lib/gollum-lib/page.rb
@@ -460,7 +460,7 @@ module Gollum
     def page_match(name, path)
       if (match = self.class.valid_filename?(path))
         @wiki.ws_subs.each do |sub|
-          return true if Page.cname(name).downcase == Page.cname(match, sub).downcase
+          return true if Page.cname(name).force_encoding('utf-8').downcase == Page.cname(match, sub).force_encoding('utf-8').downcase
         end
       end
       false


### PR DESCRIPTION
As non-english user,I find out that gollum can't support non-english filenames.
for example:
神秘博士.md
will not be display in the "all" list.

This pull request have fixed the problem,and you may have some test.

Thanks!