### PR TITLE
Make navigation macro strip root path correctly

### DIFF
--- a/lib/gollum-lib/macro/navigation.rb
+++ b/lib/gollum-lib/macro/navigation.rb
@@ -6,7 +6,7 @@ module Gollum
         if @wiki.pages.size > 0
           list_items = @wiki.pages.map do |page|
             if page.url_path.start_with?(toc_root_path)
-              path_display = full_path ? page.url_path_display  : page.url_path_display.sub(toc_root_path,"").sub(/^\//,'')
+              path_display = full_path ? page.url_path_display  : page.url_path_display.sub(toc_root_path.gsub("-", " "), "").sub(/^\//,'')
               "<li><a href=\"/#{page.url_path}\">#{path_display}</a></li>"
             end
           end


### PR DESCRIPTION
The `navigation` macro does not strip root path correctly when the path contains multiple words, while it works correctly for single word root paths. For example:

`<<navigation("Research Topic 1", "Research-Topic-1")>>` gives something like

    Research Topic 1/Ideas 1
    Research Topic 1/Ideas 2

while it should be

    Ideas 1
    Ideas 2

This PR fixes it.