### PR TITLE
Allow gollum installs with different root URLs to delete files

### DIFF
--- a/lib/gollum-lib/file_view.rb
+++ b/lib/gollum-lib/file_view.rb
@@ -25,7 +25,7 @@ module Gollum
     end
 
     def delete_file(url, valid_page)
-      %Q(<form method="POST" action="/deleteFile/#{url}" onsubmit="return confirm('Do you really want to delete the file #{url}?');"><button type="submit" name="delete" value="true"></button></form>)
+      %Q(<form method="POST" action="deleteFile/#{url}" onsubmit="return confirm('Do you really want to delete the file #{url}?');"><button type="submit" name="delete" value="true"></button></form>)
     end
 
     def new_folder(folder_path)


### PR DESCRIPTION
Update file_view.rb to allow gollum installations with different root urls than / to delete files by making the deleteFile path relative.