### PR TITLE
Fix gemspec dependencies for newer versions of bundler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
 source 'https://rubygems.org'
-gemspec
+gemspec :name => 'gollum-lib'

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,2 @@
 source 'https://rubygems.org'
-
-gemspec :name => RUBY_PLATFORM == 'java' ? 'gollum-lib_java' : 'gollum-lib'
+gemspec

--- a/gollum-lib.gemspec
+++ b/gollum-lib.gemspec
@@ -1,4 +1,8 @@
 require File.join(File.dirname(__FILE__), 'gemspec.rb')
 require File.join(File.dirname(__FILE__), 'lib', 'gollum-lib', 'version.rb')
-default_adapter = ['gollum-grit_adapter', '~> 1.0']
+  if RUBY_PLATFORM == 'java' then
+    default_adapter = ['gollum-rjgit_adapter', '~> 0.3']
+  else
+    default_adapter = ['gollum-grit_adapter', '~> 1.0']
+  end
 Gem::Specification.new &specification(Gollum::Lib::VERSION, default_adapter)


### PR DESCRIPTION
The travis specs are failing because of this error message from bundler:

```
There was an error parsing `Gemfile`: There are no gemspecs at /home/travis/build/gollum/gollum-lib. Bundler cannot continue.
```

After inspection, it turns out that this is because of changed behavior in newer versions of bundler. We use the following trick to dynamically have different gemfile dependencies for the MRI and java versions of the gem:

```
gemspec :name => RUBY_PLATFORM == 'java' ? 'gollum-lib_java' : 'gollum-lib'
```

The `:name` option used to make bundler select the gemspec with the relevant *file name*. In recent versions of bundler, it makes bundler look for a gemspec with the given name as *gem name*. Since there is no gem with the name `gollum-lib_java` defined in any of the gemspecs, it doesn't find a valid gemspec and fails.

Unfortunately, we cannot just change the *gem name* for the java version, as that would result in two different gems. Nor does bundler support a `:version` option for `gemspec` (in that case, we could have picked out the gemspec containing 'java' in the gem's *version*).

This PR fixes the problem, but not in a very nice way: essentially, I just put the dynamic bit inside `gollum-lib.gemspec` rather than in the `Gemfile`. This works, but it has the unfortunate side effect of duplicating the code inside `gollum-lib_java.gemspec`. And we still arguably need the latter file for the build process: without the java gemspec, a `rake build` command executed on MRI would only build an MRI gem.

The alternative is to give up the java-specific gemspec, which would mean we have to build gems once on MRI, and once on jruby, and release them both.