### PR TITLE
Update Nokogiri dependency to ~> 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 rvm:
-  - 2.0.0
-  - 2.1.0
-  - 2.1.1
-  - 2.2.1
-  - 2.3.0
-  - jruby-19mode
+  - 2.1.10
+  - 2.2.6
+  - 2.3.3
+  - 2.4.1
 before_install:
  - sudo apt-get update
  - sudo apt-get install libicu-dev

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Gollum-lib follows the rules of [Semantic Versioning](http://semver.org/) and us
 ## SYSTEM REQUIREMENTS
 
 - Python 2.5+ (2.7.3 recommended)
-- Ruby 1.9.3+ (1.9.3 recommended)
+- Ruby 2.1.0+ (>= 2.3.3 recommended)
 - Unix like operating system (OS X, Ubuntu, Debian, and more)
 - Will not work on Windows with the default [grit](https://github.com/github/grit) adapter, but might work via JRuby (please let us know!)
 

--- a/gemspec.rb
+++ b/gemspec.rb
@@ -26,7 +26,7 @@ def specification(version, default_adapter, platform = nil)
 
     s.add_dependency *default_adapter
     s.add_dependency 'rouge', '~> 2.0'
-    s.add_dependency 'nokogiri', '~> 1.6.8'
+    s.add_dependency 'nokogiri', '~> 1.7', '>= 1.7.1'
     s.add_dependency 'stringex', '~> 2.5.1'
     s.add_dependency 'sanitize', '~> 2.1.0'
     s.add_dependency 'github-markup', '~> 1.4.0'

--- a/test/test_unicode.rb
+++ b/test/test_unicode.rb
@@ -70,11 +70,11 @@ context "Unicode Support" do
   end
 
   test "create and read non-latin page with anchor 3" do
-    @wiki.write_page("test", :markdown, "# \"La\" faune d'Édiacara")
+    @wiki.write_page("test", :markdown, "# \"La\" faune d'édiacara")
 
     page = @wiki.page("test")
     assert_equal Gollum::Page, page.class
-    assert_equal "# \"La\" faune d'Édiacara", utf8(page.raw_data)
+    assert_equal "# \"La\" faune d'édiacara", utf8(page.raw_data)
 
     # markup.rb test: ', ", É
     doc     = Nokogiri::HTML page.formatted_data
@@ -83,8 +83,8 @@ context "Unicode Support" do
     anchors = h1 / :a
     assert_equal 1, h1s.size
     assert_equal 1, anchors.size
-    assert_equal %q(#la-faune-d-Édiacara), anchors[0]['href']
-    assert_equal %q(la-faune-d-Édiacara), anchors[0]['id']
+    assert_equal %q(#la-faune-d-édiacara), anchors[0]['href']
+    assert_equal %q(la-faune-d-édiacara), anchors[0]['id']
     assert_equal 'anchor', anchors[0]['class']
     assert_equal '', anchors[0].text
   end


### PR DESCRIPTION
Nokogiri 1.7.1 was released to address security issues:
sparklemotion/nokogiri#1615

Note that old Rubies are not supported anymore starting from Nokogiri 1.7.0:

> - Ruby 1.9.2, for which official support ended on 2014-07-31
> - Ruby 1.9.3, for which official support ended on 2015-02-23
> - Ruby 2.0.0, for which official support ended on 2016-02-24

– https://github.com/sparklemotion/nokogiri/blob/master/CHANGELOG.md#backwards-incompatibilities

The test matrix was updated accordingly.