### PR TITLE
Detect wiki formats availability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
   - 2.2.1
   - 2.3.0
   - 2.4.0
-  - jruby-19mode
+  - jruby-9.1.8.0
 before_install:
  - sudo apt-get update
  - sudo apt-get install libicu-dev

--- a/lib/gollum-lib/markup.rb
+++ b/lib/gollum-lib/markup.rb
@@ -38,13 +38,15 @@ module Gollum
       # options - Hash of options:
       #           regexp - Regexp to match against.
       #                    Defaults to exact match of ext.
+      #           enabled - Whether the markup is enabled
       #
       # If given a block, that block will be registered with GitHub::Markup to
       # render any matching pages
       def register(ext, name, options = {}, &block)
         @formats[ext] = { :name => name,
           :regexp => options.fetch(:regexp, Regexp.new(ext.to_s)),
-          :reverse_links => options.fetch(:reverse_links, false) }
+          :reverse_links => options.fetch(:reverse_links, false),
+          :enabled => options.fetch(:enabled, true) }
       end
     end
 

--- a/lib/gollum-lib/markups.rb
+++ b/lib/gollum-lib/markups.rb
@@ -31,31 +31,28 @@ module Gollum
       Kramdown::Document.new(content, :auto_ids => false, :input => "markdown").to_html
     }
 
-    # markdown, rdoc, and plain text is always supported.
-    register(:markdown,    "Markdown", :regexp => /md|mkdn?|mdown|markdown/)
-    register(:rdoc,        "RDoc")
-    register(:txt,         "Plain Text")
-
-    if MarkupRegisterUtils::gem_exists? "RedCloth"
-      register(:textile,   "Textile")
-    end
-    if MarkupRegisterUtils::gem_exists? "org-ruby"
-      register(:org,       "Org-mode")
-    end
-    if MarkupRegisterUtils::gem_exists? "creole"
-      register(:creole,    "Creole", :reverse_links => true)
-    end
-    if MarkupRegisterUtils::executable_exists? "python2"
-      register(:rest,      "reStructuredText", :regexp => /re?st(\.txt)?/)
-    end
-    if MarkupRegisterUtils::gem_exists? "asciidoctor"
-      register(:asciidoc,  "AsciiDoc")
-    end
-    if MarkupRegisterUtils::gem_exists? "wikicloth"
-      register(:mediawiki, "MediaWiki", :regexp => /(media)?wiki/, :reverse_links => true)
-    end
-    if MarkupRegisterUtils::executable_exists? "perl"
-      register(:pod,       "Pod")
-    end
+    # markdown, rdoc, and plain text are always supported.
+    register(:markdown, "Markdown", :regexp => /md|mkdn?|mdown|markdown/)
+    register(:rdoc, "RDoc")
+    register(:txt, "Plain Text")
+    # the following formats are available only when certain gem is installed
+    # or certain program exists.
+    register(:textile, "Textile",
+             :enabled => MarkupRegisterUtils::gem_exists?("RedCloth"))
+    register(:org, "Org-mode",
+             :enabled => MarkupRegisterUtils::gem_exists?("org-ruby"))
+    register(:creole, "Creole",
+             :enabled => MarkupRegisterUtils::gem_exists?("creole"),
+             :reverse_links => true)
+    register(:rest, "reStructuredText",
+             :enabled => MarkupRegisterUtils::executable_exists?("python2"),
+             :regexp => /re?st(\.txt)?/)
+    register(:asciidoc, "AsciiDoc",
+             :enabled => MarkupRegisterUtils::gem_exists?("asciidoctor"))
+    register(:mediawiki, "MediaWiki",
+             :enabled => MarkupRegisterUtils::gem_exists?("wikicloth"),
+             :regexp => /(media)?wiki/, :reverse_links => true)
+    register(:pod, "Pod",
+             :enabled => MarkupRegisterUtils::executable_exists?("perl"))
   end
 end

--- a/lib/gollum-lib/markups.rb
+++ b/lib/gollum-lib/markups.rb
@@ -17,7 +17,7 @@ module Gollum
       paths = ENV["PATH"].split(::File::PATH_SEPARATOR)
       paths.each do |path|
         exts.each do |ext|
-          exe = ::Pathname(path) + "#{name}#{ext}"
+          exe = Pathname(path) + "#{name}#{ext}"
           return true if exe.executable?
         end
       end

--- a/lib/gollum-lib/markups.rb
+++ b/lib/gollum-lib/markups.rb
@@ -1,4 +1,7 @@
 # ~*~ encoding: utf-8 ~*~
+
+require "pathname"
+
 module Gollum
   module MarkupRegisterUtils
     # Check if a gem exists. This implementation requires Gem::Specificaton to
@@ -14,8 +17,8 @@ module Gollum
       paths = ENV["PATH"].split(::File::PATH_SEPARATOR)
       paths.each do |path|
         exts.each do |ext|
-          exe = ::File.join(path, "#{name}#{ext}")
-          return true if ::File.executable?(exe) && !::File.directory?(exe)
+          exe = ::Pathname(path) + "#{name}#{ext}"
+          return true if exe.executable?
         end
       end
       return false

--- a/lib/gollum-lib/markups.rb
+++ b/lib/gollum-lib/markups.rb
@@ -7,7 +7,7 @@ module Gollum
       return Gem::Specification.find {|x| x.name == name} != nil
     end
 
-    # Check if an executable exsits. This implementation comes from
+    # Check if an executable exists. This implementation comes from
     # stackoverflow question 2108727.
     def executable_exists? name
       exts = ENV["PATHEXT"] ? ENV["PATHEXT"].split(";") : [""]

--- a/lib/gollum-lib/markups.rb
+++ b/lib/gollum-lib/markups.rb
@@ -3,13 +3,13 @@ module Gollum
   module MarkupRegisterUtils
     # Check if a gem exists. This implementation requires Gem::Specificaton to
     # be filled.
-    def gem_exists? name
-      return Gem::Specification.find {|x| x.name == name} != nil
+    def gem_exists?(name)
+      Gem::Specification.find {|spec| spec.name == name} != nil
     end
 
     # Check if an executable exists. This implementation comes from
     # stackoverflow question 2108727.
-    def executable_exists? name
+    def executable_exists?(name)
       exts = ENV["PATHEXT"] ? ENV["PATHEXT"].split(";") : [""]
       paths = ENV["PATH"].split(::File::PATH_SEPARATOR)
       paths.each do |path|

--- a/lib/gollum-lib/markups.rb
+++ b/lib/gollum-lib/markups.rb
@@ -1,20 +1,61 @@
 # ~*~ encoding: utf-8 ~*~
 module Gollum
+  module MarkupRegisterUtils
+    # Check if a gem exists. This implementation requires Gem::Specificaton to
+    # be filled.
+    def gem_exists? name
+      return Gem::Specification.find {|x| x.name == name} != nil
+    end
+
+    # Check if an executable exsits. This implementation comes from
+    # stackoverflow question 2108727.
+    def executable_exists? name
+      exts = ENV["PATHEXT"] ? ENV["PATHEXT"].split(";") : [""]
+      paths = ENV["PATH"].split(::File::PATH_SEPARATOR)
+      paths.each do |path|
+        exts.each do |ext|
+          exe = ::File.join(path, "#{name}#{ext}")
+          return true if ::File.executable?(exe) && !::File.directory?(exe)
+        end
+      end
+      return false
+    end
+  end
+end
+
+include Gollum::MarkupRegisterUtils
+
+module Gollum
   class Markup
-    
     GitHub::Markup::Markdown::MARKDOWN_GEMS['kramdown'] = proc { |content|
-        Kramdown::Document.new(content, :auto_ids => false, :input => "markdown").to_html
+      Kramdown::Document.new(content, :auto_ids => false, :input => "markdown").to_html
     }
 
-    register(:markdown,  "Markdown", :regexp => /md|mkdn?|mdown|markdown/)
-    register(:textile,   "Textile")
-    register(:rdoc,      "RDoc")
-    register(:org,       "Org-mode")
-    register(:creole,    "Creole", :reverse_links => true)
-    register(:rest,      "reStructuredText", :regexp => /re?st(\.txt)?/)
-    register(:asciidoc,  "AsciiDoc")
-    register(:mediawiki, "MediaWiki", :regexp => /(media)?wiki/, :reverse_links => true)
-    register(:pod,       "Pod")
-    register(:txt,       "Plain Text")
+    # markdown, rdoc, and plain text is always supported.
+    register(:markdown,    "Markdown", :regexp => /md|mkdn?|mdown|markdown/)
+    register(:rdoc,        "RDoc")
+    register(:txt,         "Plain Text")
+
+    if MarkupRegisterUtils::gem_exists? "RedCloth"
+      register(:textile,   "Textile")
+    end
+    if MarkupRegisterUtils::gem_exists? "org-ruby"
+      register(:org,       "Org-mode")
+    end
+    if MarkupRegisterUtils::gem_exists? "creole"
+      register(:creole,    "Creole", :reverse_links => true)
+    end
+    if MarkupRegisterUtils::executable_exists? "python2"
+      register(:rest,      "reStructuredText", :regexp => /re?st(\.txt)?/)
+    end
+    if MarkupRegisterUtils::gem_exists? "asciidoctor"
+      register(:asciidoc,  "AsciiDoc")
+    end
+    if MarkupRegisterUtils::gem_exists? "wikicloth"
+      register(:mediawiki, "MediaWiki", :regexp => /(media)?wiki/, :reverse_links => true)
+    end
+    if MarkupRegisterUtils::executable_exists? "perl"
+      register(:pod,       "Pod")
+    end
   end
 end


### PR DESCRIPTION
Gollum registers all known wiki format, regardless of whether or not the corresponding gems are installed. This confuses users sometimes, as seen in [gollum/gollum#705](https://github.com/gollum/gollum/issues/705). This PR fixes it by prefiltering formats.