### PR TITLE
Check wiki format availability

### DIFF
--- a/lib/gollum-lib/macro/navigation.rb
+++ b/lib/gollum-lib/macro/navigation.rb
@@ -6,7 +6,7 @@ module Gollum
         if @wiki.pages.size > 0
           list_items = @wiki.pages.map do |page|
             if page.url_path.start_with?(toc_root_path)
-              path_display = full_path ? page.url_path_display  : page.url_path_display.sub(toc_root_path.gsub("-", " "), "").sub(/^\//,'')
+              path_display = full_path ? page.url_path_display  : page.url_path_display.sub(toc_root_path,"").sub(/^\//,'')
               "<li><a href=\"/#{page.url_path}\">#{path_display}</a></li>"
             end
           end

--- a/lib/gollum-lib/macro/navigation.rb
+++ b/lib/gollum-lib/macro/navigation.rb
@@ -6,7 +6,7 @@ module Gollum
         if @wiki.pages.size > 0
           list_items = @wiki.pages.map do |page|
             if page.url_path.start_with?(toc_root_path)
-              path_display = full_path ? page.url_path_display  : page.url_path_display.sub(toc_root_path,"").sub(/^\//,'')
+              path_display = full_path ? page.url_path_display  : page.url_path_display.sub(toc_root_path.gsub("-", " "), "").sub(/^\//,'')
               "<li><a href=\"/#{page.url_path}\">#{path_display}</a></li>"
             end
           end

--- a/lib/gollum-lib/markup.rb
+++ b/lib/gollum-lib/markup.rb
@@ -38,13 +38,15 @@ module Gollum
       # options - Hash of options:
       #           regexp - Regexp to match against.
       #                    Defaults to exact match of ext.
+      #           enabled - Whether the markup is enabled
       #
       # If given a block, that block will be registered with GitHub::Markup to
       # render any matching pages
       def register(ext, name, options = {}, &block)
         @formats[ext] = { :name => name,
           :regexp => options.fetch(:regexp, Regexp.new(ext.to_s)),
-          :reverse_links => options.fetch(:reverse_links, false) }
+          :reverse_links => options.fetch(:reverse_links, false),
+          :enabled => options.fetch(:enabled, true) }
       end
     end
 

--- a/lib/gollum-lib/markups.rb
+++ b/lib/gollum-lib/markups.rb
@@ -1,20 +1,61 @@
 # ~*~ encoding: utf-8 ~*~
+
+require "pathname"
+
+module Gollum
+  module MarkupRegisterUtils
+    # Check if a gem exists. This implementation requires Gem::Specificaton to
+    # be filled.
+    def gem_exists?(name)
+      Gem::Specification.find {|spec| spec.name == name} != nil
+    end
+
+    # Check if an executable exists. This implementation comes from
+    # stackoverflow question 2108727.
+    def executable_exists?(name)
+      exts = ENV["PATHEXT"] ? ENV["PATHEXT"].split(";") : [""]
+      paths = ENV["PATH"].split(::File::PATH_SEPARATOR)
+      paths.each do |path|
+        exts.each do |ext|
+          exe = Pathname(path) + "#{name}#{ext}"
+          return true if exe.executable?
+        end
+      end
+      return false
+    end
+  end
+end
+
+include Gollum::MarkupRegisterUtils
+
 module Gollum
   class Markup
-    
     GitHub::Markup::Markdown::MARKDOWN_GEMS['kramdown'] = proc { |content|
         Kramdown::Document.new(content, :auto_ids => false, :smart_quotes => ["'", "'", '"', '"'].map{|char| char.codepoints.first}).to_html
     }
 
-    register(:markdown,  "Markdown", :regexp => /md|mkdn?|mdown|markdown/)
-    register(:textile,   "Textile")
-    register(:rdoc,      "RDoc")
-    register(:org,       "Org-mode")
-    register(:creole,    "Creole", :reverse_links => true)
-    register(:rest,      "reStructuredText", :regexp => /re?st(\.txt)?/)
-    register(:asciidoc,  "AsciiDoc")
-    register(:mediawiki, "MediaWiki", :regexp => /(media)?wiki/, :reverse_links => true)
-    register(:pod,       "Pod")
-    register(:txt,       "Plain Text")
+    # markdown, rdoc, and plain text are always supported.
+    register(:markdown, "Markdown", :regexp => /md|mkdn?|mdown|markdown/)
+    register(:rdoc, "RDoc")
+    register(:txt, "Plain Text")
+    # the following formats are available only when certain gem is installed
+    # or certain program exists.
+    register(:textile, "Textile",
+             :enabled => MarkupRegisterUtils::gem_exists?("RedCloth"))
+    register(:org, "Org-mode",
+             :enabled => MarkupRegisterUtils::gem_exists?("org-ruby"))
+    register(:creole, "Creole",
+             :enabled => MarkupRegisterUtils::gem_exists?("creole"),
+             :reverse_links => true)
+    register(:rest, "reStructuredText",
+             :enabled => MarkupRegisterUtils::executable_exists?("python2"),
+             :regexp => /re?st(\.txt)?/)
+    register(:asciidoc, "AsciiDoc",
+             :enabled => MarkupRegisterUtils::gem_exists?("asciidoctor"))
+    register(:mediawiki, "MediaWiki",
+             :enabled => MarkupRegisterUtils::gem_exists?("wikicloth"),
+             :regexp => /(media)?wiki/, :reverse_links => true)
+    register(:pod, "Pod",
+             :enabled => MarkupRegisterUtils::executable_exists?("perl"))
   end
 end


### PR DESCRIPTION
This commit adds functionality to check availability of wiki formats. This information can be used by gollum/gollum#1173 to visually signal the availability of wiki formats and fix gollum/gollum#705.