### PR TITLE
Allow same filename with different exts

### DIFF
--- a/lib/gollum-lib/committer.rb
+++ b/lib/gollum-lib/committer.rb
@@ -78,14 +78,12 @@ module Gollum
     # name   - The String Gollum::Page filename_stripped.
     # format - The Symbol Gollum::Page format.
     # data   - The String wiki data to store in the tree map.
-    # allow_same_ext - A Boolean determining if the tree map allows the same
-    #                  filename with the same extension.
     #
     # Raises Gollum::DuplicatePageError if a matching filename already exists.
     # This way, pages are not inadvertently overwritten.
     #
     # Returns nothing (modifies the Index in place).
-    def add_to_index(dir, name, format, data, allow_same_ext = false)
+    def add_to_index(dir, name, format, data)
       path = @wiki.page_file_name(name, format)
 
       dir  = '/' if dir.strip.empty?
@@ -108,7 +106,7 @@ module Gollum
 
           new_file_ext = ::File.extname(path).sub(/^\./, '')
 
-          if downpath == existing_file && !(allow_same_ext && new_file_ext == existing_file_ext)
+          if downpath == existing_file && (new_file_ext == existing_file_ext)
             raise DuplicatePageError.new(dir, blob.name, path)
           end
         end

--- a/test/test_wiki.rb
+++ b/test/test_wiki.rb
@@ -297,7 +297,10 @@ context "Wiki page writing" do
   test "write page is not allowed to overwrite file" do
     @wiki.write_page("Abc-Def", :markdown, "# Gollum", commit_details)
     assert_raises Gollum::DuplicatePageError do
-      @wiki.write_page("aBC-dEF", :textile, "# Gollum", commit_details)
+      @wiki.write_page("aBC-dEF", :markdown, "# Gollum", commit_details)
+    end
+    assert_nothing_raised Gollum::DuplicatePageError do
+      @wiki.write_page("Abc-Def", :textile, "# Gollum", commit_details)
     end
   end
 


### PR DESCRIPTION
When playing around with https://github.com/gollum/gollum/pull/1220 I discovered that `gollum-lib` was still throwing `DuplicatePage` errors when creating e.g. `page.md` when `page.txt` already exits. This PR takes care of the issue, throwing `DuplicatePage` only when both file name and extension matches a file in the repo. It also removes the unused and confusing `allow_same_exts` argument from `Committer#add_to_index`.