### PR TITLE
[Experimental] Render markdown with pandoc for citation support

### DIFF
--- a/lib/gollum-lib/file.rb
+++ b/lib/gollum-lib/file.rb
@@ -26,6 +26,13 @@ module Gollum
       path
     end
 
+    # Public: The SHA hash identifying this file
+    #
+    # Returns the String SHA.
+    def sha
+      @blob && @blob.id
+    end
+
     # Public: The url_path, but CGI escaped.
     #
     # Returns the String url_path

--- a/lib/gollum-lib/filter/pandoc_bib.rb
+++ b/lib/gollum-lib/filter/pandoc_bib.rb
@@ -1,0 +1,28 @@
+require 'yaml'
+require 'pathname'
+
+class Gollum::Filter::PandocBib < Gollum::Filter
+  
+  def process(data)
+    data
+  end
+
+  def extract(data)
+    return data unless @markup.metadata
+    bib_metadata = {}
+
+    ['bibliography', 'csl'].each do |bibliography_key|
+      if path = @markup.metadata[bibliography_key]
+        next unless file = @markup.wiki.file(path)
+        path = Pathname.new("#{::File.join(::Dir.tmpdir, file.sha)}#{::File.extname(path)}")
+        bib_metadata[bibliography_key] = path.to_s
+        unless path.exist?
+          path.open('w') do |copy_file|
+            copy_file.write file.raw_data
+          end
+        end
+      end
+    end
+    bib_metadata.empty? ? data : "#{bib_metadata.to_yaml}---\n#{data}"
+  end
+end

--- a/lib/gollum-lib/markup.rb
+++ b/lib/gollum-lib/markup.rb
@@ -113,7 +113,7 @@ module Gollum
       @format = format
       @name   = name
 
-      chain = [:YAML, :PlainText, :Emoji, :TOC, :RemoteCode, :Code, :Sanitize, :PlantUML, :Tags, :Render]
+      chain = [:YAML, :PlainText, :Emoji, :TOC, :RemoteCode, :Code, :Sanitize, :PlantUML, :Tags, :PandocBib, :Render]
 
       filter_chain = chain.map do |r|
         Gollum::Filter.const_get(r).new(self)

--- a/lib/gollum-lib/markups.rb
+++ b/lib/gollum-lib/markups.rb
@@ -30,8 +30,8 @@ include Gollum::MarkupRegisterUtils
 
 module Gollum
   class Markup
-    GitHub::Markup::Markdown::MARKDOWN_GEMS['kramdown'] = proc { |content|
-        Kramdown::Document.new(content, :auto_ids => false, :smart_quotes => ["'", "'", '"', '"'].map{|char| char.codepoints.first}).to_html
+    GitHub::Markup::Markdown::MARKDOWN_GEMS['pandoc-ruby'] = proc { |content|
+        PandocRuby.convert(content, :s, :from => :markdown, :to => :html, :filter => 'pandoc-citeproc')
     }
 
     # markdown, rdoc, and plain text are always supported.

--- a/lib/gollum-lib/wiki.rb
+++ b/lib/gollum-lib/wiki.rb
@@ -244,7 +244,7 @@ module Gollum
       @allow_uploads        = options.fetch :allow_uploads, false
       @per_page_uploads     = options.fetch :per_page_uploads, false
       @filter_chain         = options.fetch :filter_chain,
-                                            [:YAML, :PlainText, :TOC, :RemoteCode, :Code, :Macro, :Emoji, :Sanitize, :PlantUML, :Tags, :Render]
+                                            [:YAML, :PlainText, :TOC, :RemoteCode, :Code, :Macro, :Emoji, :Sanitize, :PlantUML, :Tags, :PandocBib, :Render]
       @filter_chain.delete(:Emoji) unless options.fetch :emoji, false
     end
 


### PR DESCRIPTION
Reading [this blog post](http://www.chriskrycho.com/2015/academic-markdown-and-citations.html) about writing academic papers in markdown and rendering with pandoc, I wondered how difficult it would be to integrate this into gollum. Pandoc supports rendering footnotes in markdown by default (as explained in the blog), as well as citations via bibtex. Lo and behold, I actually got it to work after just a little while. It's admittedly still a little hacky and I don't propose to merge this into gollum, but I wonder whether we can make use of this idea somehow (even if just as a recipe for `config.rb`).

## This PR allows the user to:
1. Use footnote syntax
2. Use citation syntax
3. Set a custom `.bib` file, committed in the wiki, through YAML frontmatter
4. *Idem* for an optional `.csl` (citation language definition) file

## How it does so:
1. Use pandoc to render markdown via the `pandoc-ruby` gem
   * requires the `pandoc` and `pandoc-citeproc` executables (`brew install` or equivalent)
2. The `YAML` filter extracts the `bibliography` and `csl` keys, which therefore aren't passed to `pandoc`. Moreover, `pandoc` does not necessarily have access to the relevant files if the wiki is bare.
   * Solution: implement new `PandocBib` filter that 1) copies the files from the wiki to a tempfile and 2) inserts new YAML frontmatter (`bibliography:` and/or `csl:` keys) pointing at the newly created tempfiles, which then gets passed to `pandoc` as part of the body of the document.

## Result

Presto! Scholarly Markdown:

![screen shot 2017-04-22 at 23 59 08](https://cloud.githubusercontent.com/assets/147111/25308695/21505546-27ba-11e7-8c0f-f0f851ecee89.png)

### Sample document

This assumes the existence of `lotr.bib` and `chicago-author-date.csl` in the wiki:

```
---
bibliography: lotr.bib
csl: chicago-author-date.csl
display_metadata: false
---

# Bilbo Baggins

Bilbo Baggins is the protagonist of The [[Hobbit]] [@tolkien2012lord] and also makes a few
appearances in The Lord of the Rings, two of the most well-known of [[J. R. R. Tolkien]]'s fantasy writings. The story of The Hobbit featuring Bilbo is also
retold from a different perspective in the Chapter The Quest of Erebor in
Unfinished Tales.[^fn]

[^fn]: And the footnote!

In Tolkien's narrative conceit, in which all the writings of Middle-earth are
'really' translations from the fictitious volume of The Red Book of Westmarch,
Bilbo is the author of The Hobbit and translator of The Silmarillion. [Contra @tolkien2012lord, ¶15, who has everything *quite* wrong.]

# References
```

## To test:

1. check out this branch of `gollum-lib` 
2. make gollum use this experimental branch (add `gem 'gollum-lib', :path => 'path/to/gollum-lib'`, remove old dependency from `gollum.gemspec`)
3. remove the `kramdown` dependency from `gollum.gemspec`
4. add the `pandoc-ruby` gem as a dependency in the `gemspec` or `Gemfile`