### PR TITLE
Refactor tags

### DIFF
--- a/lib/gollum-lib/filter.rb
+++ b/lib/gollum-lib/filter.rb
@@ -47,12 +47,24 @@ module Gollum
   class Filter
     include Gollum::Helpers
 
+    def self.to_sym
+      name.split('::').last.to_sym
+    end
+
     # Setup the object.  Sets `@markup` to be the instance of Gollum::Markup that
     # is running this filter chain, and sets `@map` to be an empty hash (for use
     # in your extract/process operations).
     def initialize(markup)
       @markup = markup
       @map    = {}
+    end
+
+    def do_process(_d)
+      skip? ? _d : process(_d)
+    end
+
+    def do_extract(_d)
+      skip? ? _d : extract(_d)
     end
 
     def extract(_d)
@@ -63,6 +75,12 @@ module Gollum
     def process(_d)
       raise RuntimeError,
             "#{self.class} has not implemented ##process!"
+    end
+
+    private
+    
+    def skip?
+      @markup.skip_filter?(self.class.to_sym)
     end
 
     protected

--- a/lib/gollum-lib/filter.rb
+++ b/lib/gollum-lib/filter.rb
@@ -47,10 +47,6 @@ module Gollum
   class Filter
     include Gollum::Helpers
 
-    def self.to_sym
-      name.split('::').last.to_sym
-    end
-
     # Setup the object.  Sets `@markup` to be the instance of Gollum::Markup that
     # is running this filter chain, and sets `@map` to be an empty hash (for use
     # in your extract/process operations).
@@ -59,28 +55,14 @@ module Gollum
       @map    = {}
     end
 
-    def do_process(_d)
-      skip? ? _d : process(_d)
-    end
-
-    def do_extract(_d)
-      skip? ? _d : extract(_d)
-    end
-
-    def extract(_d)
+    def extract(data)
       raise RuntimeError,
             "#{self.class} has not implemented ##extract!"
     end
 
-    def process(_d)
+    def process(data)
       raise RuntimeError,
             "#{self.class} has not implemented ##process!"
-    end
-
-    private
-    
-    def skip?
-      @markup.skip_filter?(self.class.to_sym)
     end
 
     protected

--- a/lib/gollum-lib/filter/code.rb
+++ b/lib/gollum-lib/filter/code.rb
@@ -6,8 +6,6 @@
 class Gollum::Filter::Code < Gollum::Filter
   def extract(data)
     case @markup.format
-    when :txt
-      return data
     when :asciidoc
       data.gsub!(/^(\[source,([^\r\n]*)\]\n)?----\n(.+?)\n----$/m) do
         cache_codeblock(Regexp.last_match[2], Regexp.last_match[3])

--- a/lib/gollum-lib/filter/plain_text.rb
+++ b/lib/gollum-lib/filter/plain_text.rb
@@ -6,6 +6,10 @@
 
 class Gollum::Filter::PlainText < Gollum::Filter
 
+    def do_process(_d)
+      skip? ? _d : process(_d)
+    end
+
   def extract(data)
     @markup.format == :txt ? "<pre>#{CGI.escapeHTML(data)}</pre>" : data
   end

--- a/lib/gollum-lib/filter/plantuml.rb
+++ b/lib/gollum-lib/filter/plantuml.rb
@@ -69,7 +69,6 @@ class Gollum::Filter::PlantUML < Gollum::Filter
   # Extract all sequence diagram blocks into the map and replace with
   # placeholders.
   def extract(data)
-    return data if @markup.format == :txt
     data.gsub(/(@startuml\r?\n.+?\r?\n@enduml\r?$)/m) do
       id       = Digest::SHA1.hexdigest($1)
       @map[id] = { :code => $1 }

--- a/lib/gollum-lib/filter/remote_code.rb
+++ b/lib/gollum-lib/filter/remote_code.rb
@@ -13,7 +13,6 @@ require 'open-uri'
 #
 class Gollum::Filter::RemoteCode < Gollum::Filter
   def extract(data)
-    return data if @markup.format == :txt
     data.gsub(/^[ \t]*``` ?([^:\n\r]+):((http)?[^`\n\r]+)```/) do
       language = Regexp.last_match[1]
       uri      = Regexp.last_match[2]

--- a/lib/gollum-lib/filter/tags.rb
+++ b/lib/gollum-lib/filter/tags.rb
@@ -75,14 +75,16 @@ class Gollum::Filter::Tags < Gollum::Filter
   # Returns the String HTML version of the tag.
   def process_tag(tag)
     content, extra = parse_link_parts(tag)
+    mime = MIME::Types.type_for(::File.extname(content.to_s)).first
+
     result = if content =~ /^_TOC_/
       %{[[#{tag}]]}
     elsif content =~ /^_$/
       %{<div class="clearfloats"></div>}
     elsif content =~ /^include:.+/
       process_include_tag(tag)
-    elsif MIME::Types.type_for(::File.extname(content.to_s)) =~ /^image/
-      process_image_tag(tag, extra)
+    elsif mime && mime.content_type =~ /^image/
+      process_image_tag(content, extra)
     elsif external = process_external_link_tag(content, extra)
       external
     end

--- a/lib/gollum-lib/filter/tags.rb
+++ b/lib/gollum-lib/filter/tags.rb
@@ -81,7 +81,7 @@ class Gollum::Filter::Tags < Gollum::Filter
       %{<div class="clearfloats"></div>}
     elsif content =~ /^include:.+/
       process_include_tag(tag)
-    elsif MIME::Types.type_for(::File.extname(content)) =~ /^image/
+    elsif MIME::Types.type_for(::File.extname(content.to_s)) =~ /^image/
       process_image_tag(tag, extra)
     elsif external = process_external_link_tag(content, extra)
       external
@@ -266,7 +266,7 @@ class Gollum::Filter::Tags < Gollum::Filter
   #
   # Returns the String HTML if the tag is a valid page link tag or nil
   #   if it is not.
-  def process_page_link_tag(name, page_name)
+  def process_page_link_tag(name, page_name = nil)
     link            = page_name ? page_name : name.to_s
     presence    = "absent"
     page = find_page_from_path(link)

--- a/lib/gollum-lib/filter/tags.rb
+++ b/lib/gollum-lib/filter/tags.rb
@@ -298,11 +298,9 @@ class Gollum::Filter::Tags < Gollum::Filter
     unless slash.nil?
       name = path[slash+1..-1]
       path = path[0..slash]
-      page = @markup.wiki.paged(name, path)
+      @markup.wiki.paged(name, path)
     else
-      page = @markup.wiki.paged(path, '/') || @markup.wiki.page(path)
+      @markup.wiki.page(path)
     end
-
-    page
   end
 end

--- a/lib/gollum-lib/filter/tags.rb
+++ b/lib/gollum-lib/filter/tags.rb
@@ -4,8 +4,6 @@
 class Gollum::Filter::Tags < Gollum::Filter
   # Extract all tags into the tagmap and replace with placeholders.
   def extract(data)
-    return data if @markup.skip_tags?
-
     data.gsub!(/(.?)\[\[(.+?)\]\]([^\[]?)/) do
       if Regexp.last_match[1] == "'" && Regexp.last_match[3] != "'"
         "[[#{Regexp.last_match[2]}]]#{Regexp.last_match[3]}"

--- a/lib/gollum-lib/filter/tags.rb
+++ b/lib/gollum-lib/filter/tags.rb
@@ -4,7 +4,8 @@
 class Gollum::Filter::Tags < Gollum::Filter
   # Extract all tags into the tagmap and replace with placeholders.
   def extract(data)
-    return data if @markup.format == :txt || @markup.format == :asciidoc
+    return data if @markup.format.skip_tags?
+    
     data.gsub!(/(.?)\[\[(.+?)\]\]([^\[]?)/) do
       if Regexp.last_match[1] == "'" && Regexp.last_match[3] != "'"
         "[[#{Regexp.last_match[2]}]]#{Regexp.last_match[3]}"

--- a/lib/gollum-lib/markup.rb
+++ b/lib/gollum-lib/markup.rb
@@ -57,6 +57,7 @@ module Gollum
         @formats[ext] = { :name => name,
           :extensions => new_extension,
           :reverse_links => options.fetch(:reverse_links, false),
+          :skip_tags => options.fetch(:skip_tags, false),
           :enabled => options.fetch(:enabled, true) }
         @extensions.concat(new_extension)
       end
@@ -97,8 +98,14 @@ module Gollum
       @to_xml_opts = { :save_with => Nokogiri::XML::Node::SaveOptions::DEFAULT_XHTML ^ 1, :indent => 0, :encoding => 'UTF-8' }
     end
 
+    # Whether or not this markup's format uses reversed-order links ([description | url] rather than [url | description]). Defaults to false.
     def reverse_links?
       self.class.formats[@format][:reverse_links]
+    end
+
+    # Whether or not Gollum tags are supported for this markup's format. Defaults to false.
+    def skip_tags?
+      self.class.formats[@format][:skip_tags]
     end
 
     # Render data using default chain in the target format.

--- a/lib/gollum-lib/markup.rb
+++ b/lib/gollum-lib/markup.rb
@@ -83,17 +83,15 @@ module Gollum
     #
     # Returns a new Gollum::Markup object, ready for rendering.
     def initialize(page)
-      if page
-        @wiki        = page.wiki
-        @name        = page.filename
-        @data        = page.text_data
-        @version     = page.version.id if page.version
-        @format      = page.format
-        @sub_page    = page.sub_page
-        @parent_page = page.parent_page
-        @page        = page
-        @dir         = ::File.dirname(page.path)
-      end
+      @wiki        = page.wiki
+      @name        = page.filename
+      @data        = page.text_data
+      @version     = page.version.id if page.version
+      @format      = page.format
+      @sub_page    = page.sub_page
+      @parent_page = page.parent_page
+      @page        = page
+      @dir         = ::File.dirname(page.path)
       @metadata    = nil
       @to_xml_opts = { :save_with => Nokogiri::XML::Node::SaveOptions::DEFAULT_XHTML ^ 1, :indent => 0, :encoding => 'UTF-8' }
     end
@@ -105,34 +103,13 @@ module Gollum
 
     # Whether or not a particular filter should be skipped for this format.
     def skip_filter?(filter)
-      if self.class.formats[@format][:skip_filters].respond_to?(:include)
+      if self.class.formats[@format][:skip_filters].respond_to?(:include?)
         self.class.formats[@format][:skip_filters].include?(filter)
       elsif self.class.formats[@format][:skip_filters].respond_to?(:call)
         self.class.formats[@format][:skip_filters].call(filter)
       else
         false
       end
-    end
-
-    # Render data using default chain in the target format.
-    #
-    # data - the data to render
-    # format - format to use as a symbol
-    # name - name using the extension of the format
-    #
-    # Returns the processed data
-    def render_default(data, format=:markdown, name='render_default.md')
-      # set instance vars so we're able to render data without a wiki or page.
-      @format = format
-      @name   = name
-
-      chain = [:YAML, :PlainText, :Emoji, :TOC, :RemoteCode, :Code, :Sanitize, :PlantUML, :Tags, :Render].reject {|filter| skip_filter?(filter)}
-
-      filter_chain = chain.map do |r|
-        Gollum::Filter.const_get(r).new(self)
-      end
-
-      process_chain data, filter_chain
     end
 
     # Process the filter chain
@@ -169,14 +146,13 @@ module Gollum
     #
     # Returns the formatted String content.
     def render(no_follow = false, encoding = nil, include_levels = 10)
-      @sanitize = no_follow ?
-          @wiki.history_sanitizer :
-          @wiki.sanitizer
+      @sanitize = no_follow ? @wiki.history_sanitizer : @wiki.sanitizer
 
       @encoding       = encoding
       @include_levels = include_levels
 
-      data         = @data.dup
+      data     = @data.dup
+
       filter_chain = @wiki.filter_chain.reject {|filter| skip_filter?(filter)}
       filter_chain.map! do |filter_sym|
         Gollum::Filter.const_get(filter_sym).new(self)

--- a/lib/gollum-lib/markups.rb
+++ b/lib/gollum-lib/markups.rb
@@ -37,7 +37,8 @@ module Gollum
     # markdown, rdoc, and plain text are always supported.
     register(:markdown, "Markdown", :extensions => ['md','mkd','mkdn','mdown','markdown'])
     register(:rdoc, "RDoc")
-    register(:txt, "Plain Text", :skip_tags => true)
+    register(:txt, "Plain Text",
+             :skip_filters => Proc.new {|filter| ![:PlainText,:YAML].include?(filter) })
     # the following formats are available only when certain gem is installed
     # or certain program exists.
     register(:textile, "Textile",
@@ -51,7 +52,7 @@ module Gollum
              :enabled => MarkupRegisterUtils::executable_exists?("python2"),
              :extensions => ['rest', 'rst', 'rst.txt', 'rest.txt'])
     register(:asciidoc, "AsciiDoc",
-             :skip_tags => true,
+             :skip_filters => [:Tags],
              :enabled => MarkupRegisterUtils::gem_exists?("asciidoctor"))
     register(:mediawiki, "MediaWiki",
              :enabled => MarkupRegisterUtils::gem_exists?("wikicloth"),

--- a/lib/gollum-lib/markups.rb
+++ b/lib/gollum-lib/markups.rb
@@ -37,7 +37,7 @@ module Gollum
     # markdown, rdoc, and plain text are always supported.
     register(:markdown, "Markdown", :extensions => ['md','mkd','mkdn','mdown','markdown'])
     register(:rdoc, "RDoc")
-    register(:txt, "Plain Text")
+    register(:txt, "Plain Text", :skip_tags => true)
     # the following formats are available only when certain gem is installed
     # or certain program exists.
     register(:textile, "Textile",
@@ -51,6 +51,7 @@ module Gollum
              :enabled => MarkupRegisterUtils::executable_exists?("python2"),
              :extensions => ['rest', 'rst', 'rst.txt', 'rest.txt'])
     register(:asciidoc, "AsciiDoc",
+             :skip_tags => true,
              :enabled => MarkupRegisterUtils::gem_exists?("asciidoctor"))
     register(:mediawiki, "MediaWiki",
              :enabled => MarkupRegisterUtils::gem_exists?("wikicloth"),

--- a/test/filter/test_emoji.rb
+++ b/test/filter/test_emoji.rb
@@ -1,11 +1,11 @@
-
 # ~*~ encoding: utf-8 ~*~
 path = File.join(File.dirname(__FILE__), "..", "helper")
 require File.expand_path(path)
+require 'ostruct'
 
 context "Gollum::Filter::Emoji" do
   setup do
-    @filter = Gollum::Filter::Emoji.new(Gollum::Markup.new(nil))
+    @filter = Gollum::Filter::Emoji.new(Gollum::Markup.new(mock_page))
   end
 
   def filter(content)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -65,6 +65,19 @@ def commit_details
     :email   => "tom@github.com" }
 end
 
+def mock_page
+  OpenStruct.new(
+      :wiki => true,
+      :filename => 'Name.md',
+      :text_data => "# Title\nData",
+      :version => nil,
+      :format => :markdown,
+      :sub_page => false,
+      :partent_page => false,
+      :path => "Name.md"
+    )
+end
+
 # test/spec/mini 3
 # http://gist.github.com/25455
 # chris@ozmm.org

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -430,7 +430,6 @@ org
       con:
       /dev/null
       \0
-      \ \ \ 
       \\\\\\\\
 
     ).each_with_index do |ugly, n|
@@ -440,6 +439,13 @@ org
       @wiki.write_page(name, :textile, "hello\n[[include:#{ugly}]]\n", commit_details)
       page1 = @wiki.page(name)
       assert_match("does not exist yet", page1.formatted_data)
+    end
+    %w(
+      \ \ \ 
+    ).each_with_index do |ugly, n|
+      @wiki.write_page(name, :textile, "hello\n[[include:#{ugly}]]\n", commit_details)
+      page1 = @wiki.page(name)
+      assert_match("no page name given", page1.formatted_data)
     end
   end
 
@@ -574,7 +580,7 @@ org
 
   test "image with float and align" do
     %w{left right}.each do |align|
-      content = "a\n\n[[alpha.jpg|float|align=#{align}]]\n\nb"
+      content = "a\n\n[[alpha.jpg|float, align=#{align}]]\n\nb"
       output  = "<p>a</p><p><span class=\"float-#{align}\"><span><img src=\"/greek/alpha.jpg\"/></span></span></p><p>b</p>"
       relative_image(content, output)
     end
@@ -593,7 +599,7 @@ org
   end
 
   test "image with frame and alt" do
-    content = "a\n\n[[alpha.jpg|frame|alt=Alpha]]\n\nb"
+    content = "a\n\n[[alpha.jpg|frame, alt=Alpha]]\n\nb"
     output  = "<p>a</p><p><span class=\"frame\"><span><img src=\"/greek/alpha.jpg\"alt=\"Alpha\"/><span>Alpha</span></span></span></p><p>b</p>"
     relative_image(content, output)
   end

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -542,7 +542,7 @@ org
     %w{em px}.each do |unit|
       %w{width height}.each do |dim|
         content = "a [[alpha.jpg|#{dim}=100#{unit}]] b"
-        output  = "<p>a<img src=\"/greek/alpha.jpg\"#{dim}=\"100#{unit}\"/>b</p>"
+        output  = "<p>a<img src=\"/greek/alpha.jpg\" #{dim}=\"100#{unit}\"/>b</p>"
         relative_image(content, output)
       end
     end
@@ -559,7 +559,7 @@ org
   test "image with vertical align" do
     %w{top texttop middle absmiddle bottom absbottom baseline}.each do |align|
       content = "a [[alpha.jpg|align=#{align}]] b"
-      output  = %Q{<p>a<img src=\"/greek/alpha.jpg\"align=\"#{align}\"/>b</p>}
+      output  = %Q{<p>a<img src=\"/greek/alpha.jpg\" align=\"#{align}\"/>b</p>}
       relative_image(content, output)
     end
   end
@@ -600,7 +600,7 @@ org
 
   test "image with frame and alt" do
     content = "a\n\n[[alpha.jpg|frame, alt=Alpha]]\n\nb"
-    output  = "<p>a</p><p><span class=\"frame\"><span><img src=\"/greek/alpha.jpg\"alt=\"Alpha\"/><span>Alpha</span></span></span></p><p>b</p>"
+    output  = "<p>a</p><p><span class=\"frame\"><span><img src=\"/greek/alpha.jpg\" alt=\"Alpha\"/><span>Alpha</span></span></span></p><p>b</p>"
     relative_image(content, output)
   end
 

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -610,6 +610,17 @@ org
   #
   #########################################################################
 
+  test "file link without description" do
+    index = @wiki.repo.index
+    index.add("alpha.csv", "hi")
+    index.commit("Add alpha.csv")
+    @wiki.write_page("Bilbo Baggins", :markdown, "a [[alpha.csv]] b", commit_details)
+
+    page   = @wiki.page("Bilbo Baggins")
+    output = Gollum::Markup.new(page).render
+    assert_html_equal %{<p>a <a href="/alpha.csv">alpha.csv</a> b</p>}, output
+  end
+
   test "file link with absolute path" do
     index = @wiki.repo.index
     index.add("alpha.jpg", "hi")


### PR DESCRIPTION
This refactor shaves about 5 seconds of load time for a page with a ridiculous amount (1000) of tags (~25 seconds vs. ~30), and (hopefully) improves readability and maintainability. To further improve performance I would like to eventually collapse the search for files and pages so we don't traverse the repository twice, and of course implement caching of the repo tree map. But that requires refactoring the `Page` and `File` classes, and implementing the idea for a `Gollum::IO` class...

Some breaking changes:
  * syntax for link attributes changed from `image.jpg|frame|alt=Bla` to `image.jpg|frame, alt=Bla`
  * image links and file links and are now also reversed if `@markup.reverse_links?` (previously only for page links and external links). This is because [reversal is now handled at the start of the link processing rather than in each method separately](https://github.com/gollum/gollum-lib/pull/269/files#diff-9c66db1000504e8fd86544f23961803eR100).
  * a page link to `waa.md` would *first* be interpreted as a relative link, and if that didn't find a page, it would be interpreted as an absolute link (to `/waa.md`). So in cases of broken links the repository was traversed twice. I've disabled this, so an absolute link now requires an explicit `/`. However, this change doesn't break any tests.