### PR TITLE
Refactor Markup class

### DIFF
--- a/lib/gollum-lib/filter/sanitize.rb
+++ b/lib/gollum-lib/filter/sanitize.rb
@@ -10,7 +10,7 @@ class Gollum::Filter::Sanitize < Gollum::Filter
       doc = Nokogiri::HTML::DocumentFragment.parse(data)
       doc = @markup.sanitize.clean_node!(doc)
 
-      doc.to_xml(@markup.to_xml_opts)
+      doc.to_xml(@markup.to_xml_opts).gsub(/<p><\/p>/, '')
     else
       data
     end

--- a/lib/gollum-lib/markup.rb
+++ b/lib/gollum-lib/markup.rb
@@ -129,11 +129,6 @@ module Gollum
         data = filter.process(data)
       end
 
-      # Finally, a little bit of cleanup, just because
-      data.gsub!(/<p><\/p>/) do
-        ''
-      end
-
       data
     end
 
@@ -202,5 +197,4 @@ module Gollum
     end
   end
 
-  MarkupGFM = Markup
 end


### PR DESCRIPTION
* Moved the cleanup of empty `<p></p>` tags to the `Sanitize` filter, which was actually causing them to be introduced.
* Removed mysterious line

Todo:
* what's with the empty caching methods, `#update_cache` and `#check_cache`?
* can we make the complicated `class << self` block at the top more readable? I find it a bit of an odd way to handle the definition of class methods.
* The `#find_files` method should be removed, but this will require some modifications to the tag filter.

Any further suggestions welcome!