### PR TITLE
Refactor wiki.rb: use Gollum class names directly

### DIFF
--- a/lib/gollum-lib/blob_entry.rb
+++ b/lib/gollum-lib/blob_entry.rb
@@ -48,7 +48,7 @@ module Gollum
     # Returns a Gollum::Page instance.
     def page(wiki, commit)
       blob         = self.blob(wiki.repo)
-      page         = wiki.page_class.new(wiki).populate(blob, self.dir)
+      page         = ::Gollum::Page.new(wiki).populate(blob, self.dir)
       page.version = commit
       page
     end
@@ -60,7 +60,7 @@ module Gollum
     # Returns a Gollum::File instance.
     def file(wiki, commit)
       blob         = self.blob(wiki.repo)
-      file         = wiki.file_class.new(wiki).populate(blob, self.dir)
+      file         = ::Gollum::File.new(wiki).populate(blob, self.dir)
       file.version = commit
       file
     end

--- a/lib/gollum-lib/file.rb
+++ b/lib/gollum-lib/file.rb
@@ -2,8 +2,7 @@
 
 module Gollum
   class File
-    Wiki.file_class = self
-
+    
     # Public: Initialize a file.
     #
     # wiki - The Gollum::Wiki in question.

--- a/lib/gollum-lib/page.rb
+++ b/lib/gollum-lib/page.rb
@@ -2,8 +2,6 @@
 module Gollum
   class Page
     include Pagination
-
-    Wiki.page_class = self
     
     SUBPAGENAMES = [:header, :footer, :sidebar]
     
@@ -240,7 +238,7 @@ module Gollum
     #
     # Returns a Gollum::Markup instance.
     def markup
-      @markup ||= @wiki.markup_classes[format].new(self)
+      @markup ||= ::Gollum::Markup.new(self)
     end
 
     # Public: The current version of the page.

--- a/lib/gollum-lib/sanitization.rb
+++ b/lib/gollum-lib/sanitization.rb
@@ -291,6 +291,16 @@ module Gollum
         end
     ].freeze
 
+    # Modifies the current Sanitization instance to sanitize older revisions
+    # of pages.
+    #
+    # Returns a Sanitization instance.
+    def self.history_sanitization
+      self.new do |sanitize|
+        sanitize.add_attributes['a'] = { 'rel' => 'nofollow' }
+      end
+    end
+
     # Gets an Array of whitelisted HTML elements.  Default: ELEMENTS.
     attr_reader :elements
 
@@ -339,16 +349,6 @@ module Gollum
     # Returns True if comments are allowed, or False.
     def allow_comments?
       !!@allow_comments
-    end
-
-    # Modifies the current Sanitization instance to sanitize older revisions
-    # of pages.
-    #
-    # Returns a Sanitization instance.
-    def history_sanitization
-      self.class.new do |sanitize|
-        sanitize.add_attributes['a'] = { 'rel' => 'nofollow' }
-      end
     end
 
     # Builds a Hash of options suitable for Sanitize.clean.

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -750,9 +750,8 @@ np.array([[2,2],[1,3]],np.float)
 ```
     END
 
-    # rendered with Gollum::Markup
     _page, rendered = render_page(content)
-    assert_markup_highlights_code Gollum::Markup, rendered
+    assert_markup_highlights_code rendered
   end
 
   test "code with trailing whitespace" do
@@ -766,13 +765,13 @@ np.array([[2,2],[1,3]],np.float)
 
     # rendered with Gollum::Markup
     _page, rendered = render_page(content)
-    assert_markup_highlights_code Gollum::Markup, rendered
+    assert_markup_highlights_code rendered
   end
 
-  def assert_markup_highlights_code(markup_class, rendered)
-    assert_match(/pre class="highlight"/, rendered, "#{markup_class} doesn't highlight code\n #{rendered}")
-    assert_match(/span class="n"/, rendered, "#{markup_class} doesn't highlight code\n #{rendered}")
-    assert_match(/\(\[\[/, rendered, "#{markup_class} parses out wiki links\n#{rendered}")
+  def assert_markup_highlights_code(rendered)
+    assert_match(/pre class="highlight"/, rendered, "Gollum::Markup doesn't highlight code\n #{rendered}")
+    assert_match(/span class="n"/, rendered, "Gollum::Markup doesn't highlight code\n #{rendered}")
+    assert_match(/\(\[\[/, rendered, "Gollum::Markup parses out wiki links\n#{rendered}")
   end
 
   test "embed code page absolute link" do

--- a/test/test_wiki.rb
+++ b/test/test_wiki.rb
@@ -4,24 +4,6 @@ require File.expand_path(File.join(File.dirname(__FILE__), "helper"))
 context "Wiki" do
   setup do
     @wiki                       = Gollum::Wiki.new(testpath("examples/lotr.git"))
-    Gollum::Wiki.markup_classes = nil
-  end
-
-  test "#markup_class gets default markup" do
-    assert_equal Gollum::Markup, Gollum::Wiki.markup_class
-  end
-
-  test "#default_markup_class= doesn't clobber alternate markups" do
-    custom    = Class.new(Gollum::Markup)
-    custom_md = Class.new(Gollum::Markup)
-
-    Gollum::Wiki.markup_classes            = Hash.new Gollum::Markup
-    Gollum::Wiki.markup_classes[:markdown] = custom_md
-    Gollum::Wiki.default_markup_class      = custom
-
-    assert_equal custom, Gollum::Wiki.default_markup_class
-    assert_equal custom, Gollum::Wiki.markup_classes[:orgmode]
-    assert_equal custom_md, Gollum::Wiki.markup_classes[:markdown]
   end
 
   test "repo path" do

--- a/test/wiki_factory.rb
+++ b/test/wiki_factory.rb
@@ -1,13 +1,18 @@
 # ~*~ encoding: utf-8 ~*~
 class WikiFactory
+  # set 'wiki-' prefix on ids for tests
+  class Gollum::Sanitization
+    def id_prefix
+      'wiki-'
+    end
+  end
+
   def self.create(p, opt = {})
     path = testpath(p)
     Gollum::Git::Repo.init_bare(path)
     Gollum::Wiki.default_options = { :universal_toc => false }.merge(opt)
     cleanup                      = Proc.new { FileUtils.rm_r File.join(File.dirname(__FILE__), *%w(examples test.git)) }
     wiki                         = Gollum::Wiki.new(path)
-    # set 'wiki-' prefix on ids for tests
-    wiki.sanitization.id_prefix  = 'wiki-'
     return wiki, path, cleanup
   end
 end


### PR DESCRIPTION
I attempted to untangle the the mess of `wiki.blah_class.new` calls. I think this simplifies the code quite a lot, without sacrificing a lot in terms of flexibility. To override anything an end user can just monkeypatch or subclass any of the provided classes. My guess is this is all an old compatibility layer, as some of the comments in the removed code also indicate.

Still, if anyone thinks this provides useful flexibility, we can keep it.