### PR TITLE
Update Nokogiri gem to a non-vulnerable version. Fixes #278

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ rvm:
   - 2.3.0
   - 2.4.0
   - jruby-19mode
+jdk:
+  - oraclejdk8
 before_install:
  - sudo apt-get update
  - sudo apt-get install libicu-dev

--- a/gemspec.rb
+++ b/gemspec.rb
@@ -26,7 +26,7 @@ def specification(version, default_adapter, platform = nil)
 
     s.add_dependency *default_adapter
     s.add_dependency 'rouge', '~> 2.0'
-    s.add_dependency 'nokogiri', '~> 1.6.4'
+    s.add_dependency 'nokogiri', '~> 1.7', '>= 1.7.1'
     s.add_dependency 'stringex', '~> 2.6'
     s.add_dependency 'sanitize', '~> 2.1'
     s.add_dependency 'github-markup', '~> 1.6'

--- a/gemspec.rb
+++ b/gemspec.rb
@@ -26,7 +26,11 @@ def specification(version, default_adapter, platform = nil)
 
     s.add_dependency *default_adapter
     s.add_dependency 'rouge', '~> 2.0'
-    s.add_dependency 'nokogiri', '>= 1.6.1', '< 2.0'
+    if RUBY_VERSION < '2.1'
+      s.add_dependency 'nokogiri', '~> 1.6.1'
+    else
+      s.add_dependency 'nokogiri', '>= 1.6.1', '< 2.0'
+    end
     s.add_dependency 'stringex', '~> 2.6'
     s.add_dependency 'sanitize', '~> 2.1'
     s.add_dependency 'github-markup', '~> 1.6'

--- a/gemspec.rb
+++ b/gemspec.rb
@@ -26,7 +26,7 @@ def specification(version, default_adapter, platform = nil)
 
     s.add_dependency *default_adapter
     s.add_dependency 'rouge', '~> 2.0'
-    s.add_dependency 'nokogiri', '~> 1.7', '>= 1.7.1'
+    s.add_dependency 'nokogiri', '>= 1.6.1', '< 2.0'
     s.add_dependency 'stringex', '~> 2.6'
     s.add_dependency 'sanitize', '~> 2.1'
     s.add_dependency 'github-markup', '~> 1.6'

--- a/lib/gollum-lib/version.rb
+++ b/lib/gollum-lib/version.rb
@@ -1,5 +1,5 @@
 module Gollum
   module Lib
-    VERSION = '4.2.5'
+    VERSION = '4.2.6'
   end
 end

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -194,7 +194,7 @@ context "Markup" do
     page = @wiki.page("Bilbo Baggins")
     assert_html_equal "<p>a <a href=\"http://example.com\">http://example.com</a> b</p>", page.formatted_data
   end
-  
+
   test "external page link with different text" do
     @wiki.write_page("Bilbo Baggins", :markdown, "a [[Words|http://example.com]] b", commit_details)
     page = @wiki.page("Bilbo Baggins")
@@ -238,7 +238,7 @@ sed -i '' 's/[[:space:]]*$//'
 org
     @wiki.write_page("Pipe", :org, code, commit_details)
     page = @wiki.page("Pipe")
-    assert_html_equal "<pre class=\"highlight\"><code>sed -i <span class=\"s1\">''</span> <span class=\"s1\">'s/[[:space:]]*$//'</span></code></pre>", page.formatted_data
+    assert_html_equal "<pre class=\"highlight\"><code>sed <span class=\"nt\">-i</span> <span class=\"s1\">''</span> <span class=\"s1\">'s/[[:space:]]*$//'</span></code></pre>", page.formatted_data
   end
 
   test "regexp gsub! backref (#383)" do
@@ -406,7 +406,7 @@ org
       con:
       /dev/null
       \0
-      \ \ \ 
+      \ \ \
       \\\\\\\\
 
     ).each_with_index do |ugly, n|
@@ -899,7 +899,7 @@ np.array([[2,2],[1,3]],np.float)
         /name="wiki-Header"/
     ]
   end
-  
+
   test "toc with h1_title does not include page title" do
     @wiki.instance_variable_set(:@h1_title, true)
     @wiki.write_page("H1Test", :markdown, "# This is the page title\n\n# Testing\n\nTest", commit_details)


### PR DESCRIPTION
Fixes #278 
Updated Nokogiri to > 1.7.1

Test suite run output:
```
Started
................................................................................................................................................................
..................................................................................................................

Finished in 14.667878 seconds.
----------------------------------------------------------------------------------------------------------------------------------------------------------------
274 tests, 635 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------
18.68 tests/s, 43.29 assertions/s
```
