### PR TITLE
Fixed issue with GlobalTOC() not working with a base_path other than / .

### DIFF
--- a/lib/gollum-lib/macro/global_toc.rb
+++ b/lib/gollum-lib/macro/global_toc.rb
@@ -3,7 +3,9 @@ module Gollum
     class GlobalTOC < Gollum::Macro
       def render(title = "Global Table of Contents")
         if @wiki.pages.size > 0
-          result = '<ul>' + @wiki.pages.map { |p| "<li><a href=\"/#{p.url_path}\">#{p.url_path_display}</a></li>" }.join + '</ul>'
+          # Strip trailing slash.  This is important if base_path is /
+          prepath=@wiki.base_path.sub(/\/$/, '')
+          result = '<ul>' + @wiki.pages.map { |p| "<li><a href=\"#{prepath}/#{p.url_path}\">#{p.url_path_display}</a></li>" }.join + '</ul>'
         end
         "<div class=\"toc\"><div class=\"toc-title\">#{title}</div>#{result}</div>"
       end


### PR DESCRIPTION
This was issue #280 on the main gollum-lib project.