### PR TITLE
Determine markup format from format name rather than filename

### DIFF
--- a/lib/gollum-lib/filter/render.rb
+++ b/lib/gollum-lib/filter/render.rb
@@ -3,7 +3,12 @@
 class Gollum::Filter::Render < Gollum::Filter
   def extract(data)
     begin
-      data = GitHub::Markup.render(@markup.name, data)
+      format = Gollum::Markup.formats[@markup.format][:name]
+      format = "rest" if format == "reStructuredText"
+      format = "org" if format == "Org-mode"
+
+      # format is determined from file extension
+      data = GitHub::Markup.render("."+format.downcase, data)
       if data.nil?
         raise "There was an error converting #{@markup.name} to HTML."
       end


### PR DESCRIPTION
I wanted to use Gollum's ability to [change file extensions associated with markup formats](https://github.com/gollum/gollum/wiki/Formats-and-extensions) to associate Markdown with the primary extension ".wiki". While I was able to get Gollum to create files with the ".wiki" extension when the Markdown format was selected in the editor, these files would not be rendered as Markdown. This persisted even after I cleared the Mediawiki and other formats.

After digging around in the code I figured out the problem: the `github/markup` gem's `render` function determines what format to use based on the filename, and `Gollum::Markup.formats` is not taken into consideration when running it.

I took a stab at hacking up a solution by providing `GitHub::Markup.render` with a fake filename using the format's `:name` as its extension. Unfortunately, I had to include a couple of hardcoded if statements to not break Org-mode and reStructuredText formatting. And really the whole solution is quite a nasty hack. Any suggestions of how to do this in a nicer way?