### PR TITLE
Bump Rouge to 3.1.0

### DIFF
--- a/gemspec.rb
+++ b/gemspec.rb
@@ -26,7 +26,7 @@ def specification(version, default_adapter, platform = nil)
     s.extra_rdoc_files = %w(README.md LICENSE)
 
     s.add_dependency *default_adapter
-    s.add_dependency 'rouge', '~> 2.1'
+    s.add_dependency 'rouge', '~> 3.1'
     s.add_dependency 'nokogiri', '~> 1.8'
     s.add_dependency 'stringex', '~> 2.6'
     s.add_dependency 'sanitize', '~> 2.1'

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -283,7 +283,8 @@ sed -i '' 's/[[:space:]]*$//'
 org
     @wiki.write_page("Pipe", :org, code, commit_details)
     page = @wiki.page("Pipe")
-    assert_html_equal "<pre class=\"highlight\"><code>sed <span class=\"nt\">-i</span> <span class=\"s1\">''</span> <span class=\"s1\">'s/[[:space:]]*$//'</span></code></pre>", page.formatted_data
+    assert_html_equal "<pre class=\"highlight\"><code><span class=\"nb\">sed</span> <span class=\"nt\">-i</span> <span class=\"s1\">''</span> <span class=\"s1\">'s/[[:space:]]*$//'</span></code></pre>\n",
+                      page.formatted_data
   end
 
   test "regexp gsub! backref (#383)" do


### PR DESCRIPTION
No external APIs have changed; only internal APIs per
https://github.com/jneen/rouge/blob/master/CHANGELOG.md