### PR TITLE
Avoid ZLib headers when compressing text. Resolves https://github.com/gollum/gollum/issues/1279 and https://github.com/gollum/gollum-lib/issues/289 .

### DIFF
--- a/lib/gollum-lib/filter/plantuml.rb
+++ b/lib/gollum-lib/filter/plantuml.rb
@@ -114,7 +114,7 @@ class Gollum::Filter::PlantUML < Gollum::Filter
   # Transcoder class in the PlantUML java code.
   def gen_url(text)
     result = ""
-    compressedData = Zlib::Deflate.deflate(text)
+    compressedData = Zlib::Deflate.new(nil, -Zlib::MAX_WBITS).deflate(text, Zlib::FINISH)
     compressedData.chars.each_slice(3) do |bytes|
       #print bytes[0], ' ' , bytes[1] , ' ' , bytes[2]
       b1 = bytes[0].nil? ? 0 : (bytes[0].ord & 0xFF)

--- a/lib/gollum-lib/filter/plantuml.rb
+++ b/lib/gollum-lib/filter/plantuml.rb
@@ -115,8 +115,8 @@ class Gollum::Filter::PlantUML < Gollum::Filter
   def gen_url(text)
     result = ""
     compressedData = Zlib::Deflate.new(nil, -Zlib::MAX_WBITS).deflate(text, Zlib::FINISH)
+
     compressedData.chars.each_slice(3) do |bytes|
-      #print bytes[0], ' ' , bytes[1] , ' ' , bytes[2]
       b1 = bytes[0].nil? ? 0 : (bytes[0].ord & 0xFF)
       b2 = bytes[1].nil? ? 0 : (bytes[1].ord & 0xFF)
       b3 = bytes[2].nil? ? 0 : (bytes[2].ord & 0xFF)

--- a/test/filter/test_plantuml.rb
+++ b/test/filter/test_plantuml.rb
@@ -9,9 +9,9 @@ context "Page" do
 
   test "generate platuml img tags" do
 
-    FIRST_URL = "http://localhost:8080/plantuml/png/U9o5a4qAmZ0GXVSvnT1zBb14IX75TK-GcX-2wGnCaeAtDwOjM1LSpdlVlFdfObASyXJ4e38JWZp2DVgWCxTmomciHsTOh1h8uf-CSXHQi9HHWqTWFnTaaIjneH3or49C50nOfaaiKdMRteUHe5VEUOpD3llm5lxCfDzvL-OXZ0_HK-dn30SflwcaxeMggHltCurDoen6hmlixTeogDSjQjwOKl-9IYGwWxhyzGa9rdHb"
+    FIRST_URL = "http://localhost:8080/plantuml/png/XP1D2i8m48NtESNGVIvGH4eHnNLFa9eVWkaCJ9A2jpUcBLWLNCvxtxpvwM9IdF8KnA0o4u8ymZNwe3EtSCi9h4TdMAmQoEAVZ78KMh2KKOD7O3yNP94hSQ4GyjH2J1GCMAP9B59rczw7aQ1NpdcCpGxxy1R-pAJVULVc8OmFqLFfyGm7AR-ffEw5ggaRzpEDJSgCHgyBxEtQCgZNBMhUc5B_YKeaEeEw_FK9"
 
-    SECOND_URL = "http://localhost:8080/plantuml/png/U9npA2v9B2efpStXYdPFp4bCASfCpOa5iZDpTDD1V23RDQSeFm_4S3wyjYWbCGyadPYNafYJ5ilba9gN0jGC08cq6OO0"
+    SECOND_URL = "http://localhost:8080/plantuml/png/SoWkIImgAStDuOfsJyn9J2dAJCs91R8pStJJGNmWspMdA3yFn70-lBOe9J4F99sObvAOanRBvP2QbmBK3000"
 
     Gollum::Filter::PlantUML.configure do |config|
       config.test = true # Skip server checks

--- a/test/filter/test_plantuml.rb
+++ b/test/filter/test_plantuml.rb
@@ -1,5 +1,5 @@
 # ~*~ encoding: utf-8 ~*~
-require File.expand_path(File.join(File.dirname(__FILE__), "helper"))
+require File.expand_path(File.join(File.dirname(__FILE__), "..", "helper"))
 
 context "Page" do
 


### PR DESCRIPTION
Avoid ZLib headers when compressing text. Resolves https://github.com/gollum/gollum/issues/1279 and https://github.com/gollum/gollum-lib/issues/289 .