### PR TITLE
Some fixes when moving a page using a multi committer

### DIFF
--- a/lib/gollum-lib/wiki.rb
+++ b/lib/gollum-lib/wiki.rb
@@ -440,7 +440,7 @@ module Gollum
     # Returns the String SHA1 of the newly written version, or the
     # Gollum::Committer instance if this is part of a batch update.
     def update_page(page, name, format, data, commit = {})
-      name     = name.present? ? ::File.basename(name) : page.name
+      name     = name ? ::File.basename(name) : page.name
       format   ||= page.format
       dir      = ::File.dirname(page.path)
       dir      = '' if dir == '.'
@@ -973,7 +973,14 @@ module Gollum
     end
 
     def raw_data_in_commiter(committer, dir, filename)
-      committer.tree.dig(*dir.split(::File::SEPARATOR), filename)
+      data = nil
+
+      [*dir.split(::File::SEPARATOR), filename].each do |key|
+        data = data ? data[key] : committer.tree[key]
+        break unless data
+      end
+
+      data
     end
   end
 end


### PR DESCRIPTION
I'm trying to simulate a move (rename) operation that also can update the content of a page using the same commit, and, therefore, the same commiter.

I have realized that there are a couple of things that should be done in order to implement this. If we want to move a page we have to check first if the page has been renamed or modified in the committer tree. And, according to that information pick the right information to perform the `rename_page` operation.