### PR TITLE
Fix twitter-text to last stable version pre 2.x.

### DIFF
--- a/gemspec.rb
+++ b/gemspec.rb
@@ -32,6 +32,7 @@ def specification(version, default_adapter, platform = nil)
     s.add_dependency 'sanitize', '~> 2.1'
     s.add_dependency 'github-markup', '~> 1.6'
     s.add_dependency 'gemojione', '~> 3.2'
+    s.add_dependency 'twitter-text', '1.14.7'
 
     s.add_development_dependency 'org-ruby', '~> 0.9.9'
     s.add_development_dependency 'kramdown', '~> 1.13'


### PR DESCRIPTION
Fix twitter-text to last stable version pre 2.x. This should fix the wikicloth issues on Travis with Twitter::Autolink constant missing and idn-ruby not being compatible with JRuby.