### PR TITLE
Upgrade Sanitize to 4.6.4 to fix CVE-2018-3740

### DIFF
--- a/gemspec.rb
+++ b/gemspec.rb
@@ -32,7 +32,7 @@ def specification(version, default_adapter, platform = nil)
       s.add_dependency 'nokogiri', '>= 1.6.1', '< 2.0'
     end
     s.add_dependency 'stringex', '~> 2.6'
-    s.add_dependency 'sanitize', '~> 2.1'
+    s.add_dependency 'sanitize', '~> 4.6.4'
     s.add_dependency 'github-markup', '~> 1.6'
     s.add_dependency 'gemojione', '~> 3.2'
 

--- a/lib/gollum-lib/filter/sanitize.rb
+++ b/lib/gollum-lib/filter/sanitize.rb
@@ -8,7 +8,7 @@ class Gollum::Filter::Sanitize < Gollum::Filter
   def process(data)
     if @markup.sanitize
       doc = Nokogiri::HTML::DocumentFragment.parse(data)
-      doc = @markup.sanitize.clean_node!(doc)
+      doc = @markup.sanitize.node!(doc)
 
       doc.to_xml(@markup.to_xml_opts)
     else

--- a/lib/gollum-lib/page.rb
+++ b/lib/gollum-lib/page.rb
@@ -121,7 +121,7 @@ module Gollum
     #
     # Returns the fully sanitized String title.
     def title
-      Sanitize.clean(name).strip
+      Sanitize.fragment(name).strip
     end
 
     # Public: Determines if this is a sub-page

--- a/lib/gollum-lib/sanitization.rb
+++ b/lib/gollum-lib/sanitization.rb
@@ -150,7 +150,7 @@ module Gollum
       end
     end
 
-    # Builds a Hash of options suitable for Sanitize.clean.
+    # Builds a Hash of options suitable for Sanitize.fragment.
     #
     # Returns a Hash.
     def to_hash

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -16,7 +16,7 @@ context "Markup" do
     assert @wiki.pages[0].formatted_data
   end
 
-  # This test is to assume that Sanitize.clean doesn't raise Encoding::CompatibilityError on ruby 1.9
+  # This test is to assume that Sanitize.fragment doesn't raise Encoding::CompatibilityError on ruby 1.9
   test "formats non ASCII-7 character page from Wiki#pages" do
     wiki = Gollum::Wiki.new(testpath("examples/yubiwa.git"))
     assert_nothing_raised(defined?(Encoding) && Encoding::CompatibilityError) do


### PR DESCRIPTION
Sanitize <= 4.6.2 has an HTML injection vulnerability due to unsafe behavior in libxml2. This upgrades Sanitize to 4.6.4, which is not vulnerable.

See https://github.com/rgrove/sanitize/issues/176 for more details. Please let me know if you have any questions.

Note: Two tests failed on my machine before this patch. The same two tests fail in the same way after this patch, so I'm calling that a success.

