### PR TITLE
Do not render alt caption unless image is framed

### DIFF
--- a/lib/gollum-lib/filter/tags.rb
+++ b/lib/gollum-lib/filter/tags.rb
@@ -302,7 +302,7 @@ class Gollum::Filter::Tags < Gollum::Filter
       %{<span class="#{classes.join(' ')}">} +
           %{<span>} +
           %{<img src="#{path}" #{attr_string}/>} +
-          (attrs[:alt] ? %{<span>#{attrs[:alt]}</span>} : '') +
+          (classes.include?('frame') && attrs[:alt] ? %{<span>#{attrs[:alt]}</span>} : '') +
           %{</span>} +
           %{</span>}
     else

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -620,6 +620,12 @@ org
     relative_image(content, output)
   end
 
+  test "image with align and alt" do
+    content = "a [[alpha.jpg|alt=Alpha Dog, align=center]] b"
+    output  ="<p>a<span class=\"align-center\"><span><img src=\"/greek/alpha.jpg\" alt=\"Alpha Dog\"/></span></span>b</p>"
+    relative_image(content, output)
+  end
+
   test "image with frame and alt" do
     content = "a\n\n[[alpha.jpg|frame, alt=Alpha]]\n\nb"
     output  = "<p>a</p><p><span class=\"frame\"><span><img src=\"/greek/alpha.jpg\" alt=\"Alpha\"/><span>Alpha</span></span></span></p><p>b</p>"


### PR DESCRIPTION
While investigating https://github.com/gollum/gollum/issues/838 I discovered that adding `align=center,alt=Bla` to an image with not only result in the image having the (correct) `alt="Blah"` attribute and the correct alignment, but also in `Blah` being rendered, as text, after the image. That is, it's mistakenly trying to rendering "Blah" as a caption:

<img width="747" alt="screen shot 2018-10-02 at 14 40 07" src="https://user-images.githubusercontent.com/147111/46349023-27f7c500-c651-11e8-8bd1-d5d76daf644c.png">

Rendering of the caption should in fact only happen if one uses  `[[image.jpg|alt=bla,frame]]`:

<img width="1038" alt="screen shot 2018-10-02 at 14 40 22" src="https://user-images.githubusercontent.com/147111/46349034-347c1d80-c651-11e8-9d2d-33f570015e0a.png">

This PR resolves the issue by improving the check that determines whether the caption should be added, and includes a regression test.