### PR TITLE
Update kramdown and disable kramdown math handling

### DIFF
--- a/gemspec.rb
+++ b/gemspec.rb
@@ -35,7 +35,7 @@ def specification(version, default_adapter, platform = nil)
     s.add_dependency 'twitter-text', '1.14.7'
 
     s.add_development_dependency 'org-ruby', '~> 0.9.9'
-    s.add_development_dependency 'kramdown', '~> 1.13'
+    s.add_development_dependency 'kramdown', '~> 1.17'
     s.add_development_dependency 'RedCloth', '~> 4.2.9'
     s.add_development_dependency 'mocha', '~> 1.2.0'
     s.add_development_dependency 'shoulda', '~> 3.5.0'

--- a/lib/gollum-lib/markups.rb
+++ b/lib/gollum-lib/markups.rb
@@ -56,7 +56,7 @@ end
 module Gollum
   class Markup
     GitHub::Markup::Markdown::MARKDOWN_GEMS['kramdown'] = proc { |content|
-        Kramdown::Document.new(content, :input => "GFM", :auto_ids => false, :smart_quotes => ["'", "'", '"', '"'].map{|char| char.codepoints.first}).to_html
+        Kramdown::Document.new(content, :input => "GFM", :auto_ids => false, :math_engine => nil, :smart_quotes => ["'", "'", '"', '"'].map{|char| char.codepoints.first}).to_html
     }
     GitHub::Markup::Markdown::MARKDOWN_GEMS['pandoc-ruby'] = proc { |content|
         PandocRuby.convert(content, :s, :from => :markdown, :to => :html, :filter => 'pandoc-citeproc')


### PR DESCRIPTION
`kramdown`'s own attempt to handle math was inserting `<script>` tags into the rendered data which was then being sanitized, thus breaking math support altogether. Also see https://github.com/gollum/gollum/pull/1325