### PR TITLE
Implement global metadata

### DIFF
--- a/lib/gollum-lib/page.rb
+++ b/lib/gollum-lib/page.rb
@@ -225,7 +225,7 @@ module Gollum
     def metadata
       unless @metadata
         formatted_data if markup.metadata == nil
-        @metadata = (markup.metadata || {}).merge(@wiki.metadata)
+        @metadata = @wiki.metadata.merge(markup.metadata || {})
       else
         @metadata
       end

--- a/lib/gollum-lib/page.rb
+++ b/lib/gollum-lib/page.rb
@@ -223,8 +223,13 @@ module Gollum
     #
     # Returns Hash of metadata.
     def metadata
-      formatted_data if markup.metadata == nil
-      markup.metadata || {}
+      unless @metadata
+        formatted_data if markup.metadata == nil
+        @metadata = markup.metadata || {}
+        @metadata.merge(@wiki.metadata)
+      else
+        @metadata
+      end
     end
 
     # Public: The format of the page.

--- a/lib/gollum-lib/page.rb
+++ b/lib/gollum-lib/page.rb
@@ -225,8 +225,7 @@ module Gollum
     def metadata
       unless @metadata
         formatted_data if markup.metadata == nil
-        @metadata = markup.metadata || {}
-        @metadata.merge(@wiki.metadata)
+        @metadata = (markup.metadata || {}).merge(@wiki.metadata)
       else
         @metadata
       end

--- a/lib/gollum-lib/wiki.rb
+++ b/lib/gollum-lib/wiki.rb
@@ -78,6 +78,9 @@ module Gollum
     # works, and what filter classes need to implement.
     attr_reader :filter_chain
 
+    # Global metadata to be merged into the metadata for each page
+    attr_reader :metadata
+
     # Public: Initialize a new Gollum Repo.
     #
     # path    - The String path to the Git repository that holds the Gollum
@@ -141,6 +144,7 @@ module Gollum
           options[:user_icons] : 'none'
       @allow_uploads        = options.fetch :allow_uploads, false
       @per_page_uploads     = options.fetch :per_page_uploads, false
+      @metadata             = options.fetch :metadata, {}
       @filter_chain         = options.fetch :filter_chain,
                                             [:YAML, :BibTeX, :PlainText, :TOC, :RemoteCode, :Code, :Macro, :Emoji, :Sanitize, :PlantUML, :Tags, :PandocBib, :Render]
       @filter_chain.delete(:Emoji) unless options.fetch :emoji, false

--- a/test/test_page.rb
+++ b/test/test_page.rb
@@ -293,5 +293,10 @@ context "with global metadata" do
     assert_equal result, page.metadata
   end
 
-
+  test "page metadata overrides global metadata" do
+    page = @wiki.page('Elrond')
+    @wiki.stubs(:metadata).returns({'race' => 'wombat'})
+    result = {'race' => 'elf'}
+    assert_equal result, page.metadata
+  end
 end

--- a/test/test_page.rb
+++ b/test/test_page.rb
@@ -197,7 +197,6 @@ context "Page" do
       })
     assert_equal false, page.display_metadata?
   end
-
 end
 
 context "with a checkout" do
@@ -275,4 +274,24 @@ context "with custom markup engines" do
     assert page.raw_data.include? 'Time'
     assert page.raw_data =~ /^[\s\-]*$/
   end
+end
+
+context "with global metadata" do
+  setup do
+    @metadata = {'header_enum' => 'true'}
+    @wiki = Gollum::Wiki.new(testpath("examples/lotr.git"), :metadata => @metadata)
+  end
+
+  test "global metadata available on each page" do
+    page = @wiki.page('Bilbo-Baggins')
+    assert_equal @metadata, page.metadata
+  end
+
+  test "global metadata merges with page specific metadata" do
+    page = @wiki.page('Elrond')
+    result = {'race' => 'elf'}.merge(@metadata)
+    assert_equal result, page.metadata
+  end
+
+
 end


### PR DESCRIPTION
In `gollum` this will allow defining `wiki_options[:metadata]` in a `config.rb` in order to set global metadata.