### PR TITLE
Fix encodings for filenames

### DIFF
--- a/lib/gollum-lib/file.rb
+++ b/lib/gollum-lib/file.rb
@@ -39,7 +39,7 @@ module Gollum
     #
     # Returns the String url_path
     def escaped_url_path
-      ERB::Util.url_encode(self.url_path).gsub('%2F', '/')
+      ERB::Util.url_encode(self.url_path).gsub('%2F', '/').force_encoding('utf-8')
     end
 
     # Public: The on-disk filename of the file.

--- a/lib/gollum-lib/filter/tags.rb
+++ b/lib/gollum-lib/filter/tags.rb
@@ -223,7 +223,7 @@ class Gollum::Filter::Tags < Gollum::Filter
     presence  = :page_present if page
 
     name = pretty_name ? pretty_name : link
-    link = page ? page.escaped_url_path : ERB::Util.url_encode(link)
+    link = page ? page.escaped_url_path : ERB::Util.url_encode(link).force_encoding('utf-8')
     generate_link(link, name, extra, presence)
   end
 

--- a/lib/gollum-lib/page.rb
+++ b/lib/gollum-lib/page.rb
@@ -137,7 +137,7 @@ module Gollum
     #
     # Returns the String url_path
     def escaped_url_path
-      ERB::Util.url_encode(self.url_path).gsub('%2F', '/')
+      ERB::Util.url_encode(self.url_path).gsub('%2F', '/').force_encoding('utf-8')
     end
 
     # Public: Metadata title


### PR DESCRIPTION
Turns out `ERB::url_encode` is [forcing](https://apidock.com/ruby/ERB/Util/url_encode#) ASCII-8bit, which is causing https://github.com/gollum/gollum/issues/1339