### PR TITLE
Add gollum-wide support for CriticMarkup.

### DIFF
--- a/lib/gollum-lib/filter/critic_markup.rb
+++ b/lib/gollum-lib/filter/critic_markup.rb
@@ -22,7 +22,7 @@ class Gollum::Filter::CriticMarkup < Gollum::Filter
   def extract(data)
     data.gsub! ADDITION_PATTERN do
       content = $~[:content]
-      placeholder = "CRITIC" + Digest::SHA1.hexdigest("#{content}#{@map.size+1}")
+      placeholder = "CRITIC" + Digest::SHA1.hexdigest("#{content}#{@map.size}")
     	# Is there a new paragraph followed by new text
       if content.start_with?("\n\n") && content != "\n\n"
         html = "\n\n<ins class='critic break'>&nbsp;</ins>\n\n<ins>#{content.gsub('\n', ' ')}</ins>"
@@ -41,7 +41,7 @@ class Gollum::Filter::CriticMarkup < Gollum::Filter
     
     data.gsub! DELETION_PATTERN do
       content = $~[:content]
-      placeholder = "CRITIC" + Digest::SHA1.hexdigest("#{content}#{@map.size+1}")
+      placeholder = "CRITIC" + Digest::SHA1.hexdigest("#{content}#{@map.size}")
       if content == "\n\n"
         html = "<del>&nbsp;</del>"
       else
@@ -54,7 +54,7 @@ class Gollum::Filter::CriticMarkup < Gollum::Filter
     data.gsub! SUBSTITUTION_PATTERN do
       oldcontent = $~[:oldcontent]
       newcontent = $~[:newcontent]
-      placeholder = "CRITIC" + Digest::SHA1.hexdigest("#{oldcontent}#{newcontent}#{@map.size+1}")
+      placeholder = "CRITIC" + Digest::SHA1.hexdigest("#{oldcontent}#{newcontent}#{@map.size}")
       html = "<del>#{oldcontent}</del><ins>#{newcontent}</ins>"
       @map[placeholder] = html
       placeholder
@@ -63,7 +63,7 @@ class Gollum::Filter::CriticMarkup < Gollum::Filter
     data.gsub! HIGHLIGHT_PATTERN do
       content = $~[:content]
       comment = $~[:comment]
-      placeholder = "CRITIC" + Digest::SHA1.hexdigest("#{content}#{@map.size+1}")
+      placeholder = "CRITIC" + Digest::SHA1.hexdigest("#{content}#{@map.size}")
       html = "<mark>#{content}</mark><span class='critic comment'>#{comment}</span>"
       @map[placeholder] = html
       placeholder
@@ -71,7 +71,7 @@ class Gollum::Filter::CriticMarkup < Gollum::Filter
     
     data.gsub! COMMENT_PATTERN do
       content = $~[:content]
-      placeholder = "CRITIC" + Digest::SHA1.hexdigest("#{content}#{@map.size+1}")
+      placeholder = "CRITIC" + Digest::SHA1.hexdigest("#{content}#{@map.size}")
       html = "<span class='critic comment'>#{content}</span>"
       @map[placeholder] = html
       placeholder

--- a/lib/gollum-lib/filter/critic_markup.rb
+++ b/lib/gollum-lib/filter/critic_markup.rb
@@ -16,13 +16,13 @@ class Gollum::Filter::CriticMarkup < Gollum::Filter
   HIGHLIGHT_PATTERN     = %r|{\=\=(?<content>.*?)[ \t]*(\[(.*?)\])?[ \t]*\=\=\}{>>(?<comment>.*?)<<}|m
   COMMENT_PATTERN       = %r|{>>(?<content>.*?)<<}|m
 
-  PROCESS_PATTERN       = /(?<placeholder>CRITIC\h+)/
+  PROCESS_PATTERN       = /(?<placeholder>=CRITIC\h{40})/
 
 
   def extract(data)
     data.gsub! ADDITION_PATTERN do
       content = $~[:content]
-      placeholder = "CRITIC" + Digest::SHA1.hexdigest("#{content}#{@map.size}")
+      placeholder = "=CRITIC" + Digest::SHA1.hexdigest("#{content}#{@map.size}")
     	# Is there a new paragraph followed by new text
       if content.start_with?("\n\n") && content != "\n\n"
         html = "\n\n<ins class='critic break'>&nbsp;</ins>\n\n<ins>#{content.gsub('\n', ' ')}</ins>"
@@ -41,7 +41,7 @@ class Gollum::Filter::CriticMarkup < Gollum::Filter
     
     data.gsub! DELETION_PATTERN do
       content = $~[:content]
-      placeholder = "CRITIC" + Digest::SHA1.hexdigest("#{content}#{@map.size}")
+      placeholder = "=CRITIC" + Digest::SHA1.hexdigest("#{content}#{@map.size}")
       if content == "\n\n"
         html = "<del>&nbsp;</del>"
       else
@@ -54,7 +54,7 @@ class Gollum::Filter::CriticMarkup < Gollum::Filter
     data.gsub! SUBSTITUTION_PATTERN do
       oldcontent = $~[:oldcontent]
       newcontent = $~[:newcontent]
-      placeholder = "CRITIC" + Digest::SHA1.hexdigest("#{oldcontent}#{newcontent}#{@map.size}")
+      placeholder = "=CRITIC" + Digest::SHA1.hexdigest("#{oldcontent}#{newcontent}#{@map.size}")
       html = "<del>#{oldcontent}</del><ins>#{newcontent}</ins>"
       @map[placeholder] = html
       placeholder
@@ -63,7 +63,7 @@ class Gollum::Filter::CriticMarkup < Gollum::Filter
     data.gsub! HIGHLIGHT_PATTERN do
       content = $~[:content]
       comment = $~[:comment]
-      placeholder = "CRITIC" + Digest::SHA1.hexdigest("#{content}#{@map.size}")
+      placeholder = "=CRITIC" + Digest::SHA1.hexdigest("#{content}#{@map.size}")
       html = "<mark>#{content}</mark><span class='critic comment'>#{comment}</span>"
       @map[placeholder] = html
       placeholder
@@ -71,7 +71,7 @@ class Gollum::Filter::CriticMarkup < Gollum::Filter
     
     data.gsub! COMMENT_PATTERN do
       content = $~[:content]
-      placeholder = "CRITIC" + Digest::SHA1.hexdigest("#{content}#{@map.size}")
+      placeholder = "=CRITIC" + Digest::SHA1.hexdigest("#{content}#{@map.size}")
       html = "<span class='critic comment'>#{content}</span>"
       @map[placeholder] = html
       placeholder

--- a/lib/gollum-lib/filter/critic_markup.rb
+++ b/lib/gollum-lib/filter/critic_markup.rb
@@ -30,7 +30,7 @@ class Gollum::Filter::CriticMarkup < Gollum::Filter
       elsif content == "\n\n"
         html = "\n\n<ins class='critic break'>&nbsp;</ins>\n\n"
     	# Is it added text followed by a new paragraph?
-  	  elsif content.end_with?("\n\n") && content != "\n\n"
+      elsif content.end_with?("\n\n") && content != "\n\n"
   	    html = "<ins>#{content.gsub('\n', ' ')}</ins>\n\n<ins class='critic break'>&nbsp;</ins>\n\n"
       else
         html = "<ins>#{content.gsub('\n', ' ')}</ins>"

--- a/lib/gollum-lib/filter/critic_markup.rb
+++ b/lib/gollum-lib/filter/critic_markup.rb
@@ -1,0 +1,93 @@
+# ~*~ encoding: utf-8 ~*~
+
+# CriticMarkup
+#
+# Render CriticMarkup
+
+class Gollum::Filter::CriticMarkup < Gollum::Filter
+
+  # Patterns inspired by https://github.com/DivineDominion/criticmarkup.tmbundle/blob/master/Syntaxes/criticmarkup.tmLanguage
+  # All patterns use multiline matching (m flag)
+  # Logic inspired by https://github.com/CriticMarkup/CriticMarkup-toolkit/blob/master/CLI/criticParser_CLI.py
+  
+  ADDITION_PATTERN      = %r|{\+\+(?<content>.*?)\+\+[ \t]*(\[(.*?)\])?[ \t]*\}|m
+  DELETION_PATTERN      = %r|{--(?<content>.*?)--[ \t]*(\[(.*?)\])?[ \t]*\}|m
+  SUBSTITUTION_PATTERN  = %r|{~~(?<oldcontent>.*?)~>(?<newcontent>.*?)~~}|m
+  HIGHLIGHT_PATTERN     = %r|{\=\=(?<content>.*?)[ \t]*(\[(.*?)\])?[ \t]*\=\=\}{>>(?<comment>.*?)<<}|m
+  COMMENT_PATTERN       = %r|{>>(?<content>.*?)<<}|m
+
+  PROCESS_PATTERN       = /(?<placeholder>CRITIC\h+)/
+
+
+  def extract(data)
+    data.gsub! ADDITION_PATTERN do
+      content = $~[:content]
+      placeholder = "CRITIC" + Digest::SHA1.hexdigest("#{content}#{@map.size+1}")
+    	# Is there a new paragraph followed by new text
+      if content.start_with?("\n\n") && content != "\n\n"
+        html = "\n\n<ins class='critic break'>&nbsp;</ins>\n\n<ins>#{content.gsub('\n', ' ')}</ins>"
+    	# Is the addition just a single new paragraph
+      elsif content == "\n\n"
+        html = "\n\n<ins class='critic break'>&nbsp;</ins>\n\n"
+    	# Is it added text followed by a new paragraph?
+  	  elsif content.end_with?("\n\n") && content != "\n\n"
+  	    html = "<ins>#{content.gsub('\n', ' ')}</ins>\n\n<ins class='critic break'>&nbsp;</ins>\n\n"
+      else
+        html = "<ins>#{content.gsub('\n', ' ')}</ins>"
+      end
+      @map[placeholder] = html
+      placeholder
+    end
+    
+    data.gsub! DELETION_PATTERN do
+      content = $~[:content]
+      placeholder = "CRITIC" + Digest::SHA1.hexdigest("#{content}#{@map.size+1}")
+      if content == "\n\n"
+        html = "<del>&nbsp;</del>"
+      else
+        html = "<del>#{content.gsub('\n\n', ' ')}</del>"
+      end
+      @map[placeholder] = html
+      placeholder
+    end   
+    
+    data.gsub! SUBSTITUTION_PATTERN do
+      oldcontent = $~[:oldcontent]
+      newcontent = $~[:newcontent]
+      placeholder = "CRITIC" + Digest::SHA1.hexdigest("#{oldcontent}#{newcontent}#{@map.size+1}")
+      html = "<del>#{oldcontent}</del><ins>#{newcontent}</ins>"
+      @map[placeholder] = html
+      placeholder
+    end
+
+    data.gsub! HIGHLIGHT_PATTERN do
+      content = $~[:content]
+      comment = $~[:comment]
+      placeholder = "CRITIC" + Digest::SHA1.hexdigest("#{content}#{@map.size+1}")
+      html = "<mark>#{content}</mark><span class='critic comment'>#{comment}</span>"
+      @map[placeholder] = html
+      placeholder
+    end
+    
+    data.gsub! COMMENT_PATTERN do
+      content = $~[:content]
+      placeholder = "CRITIC" + Digest::SHA1.hexdigest("#{content}#{@map.size+1}")
+      html = "<span class='critic comment'>#{content}</span>"
+      @map[placeholder] = html
+      placeholder
+    end
+    
+    data
+  end
+
+
+
+  def process(data)
+    data.gsub! PROCESS_PATTERN do 
+      @map[$~[:placeholder]]
+    end
+    data
+  end
+
+
+end

--- a/lib/gollum-lib/wiki.rb
+++ b/lib/gollum-lib/wiki.rb
@@ -136,6 +136,7 @@ module Gollum
       @collapse_tree        = options.fetch :collapse_tree, false
       @css                  = options.fetch :css, false
       @emoji                = options.fetch :emoji, false
+      @critic_markup        = options.fetch :critic_markup, false
       @h1_title             = options.fetch :h1_title, false
       @display_metadata     = options.fetch :display_metadata, true
       @index_page           = options.fetch :index_page, 'Home'
@@ -146,9 +147,10 @@ module Gollum
       @per_page_uploads     = options.fetch :per_page_uploads, false
       @metadata             = options.fetch :metadata, {}
       @filter_chain         = options.fetch :filter_chain,
-                                            [:YAML, :BibTeX, :PlainText, :TOC, :RemoteCode, :Code, :Macro, :Emoji, :Sanitize, :PlantUML, :Tags, :PandocBib, :Render]
+                                            [:YAML, :BibTeX, :PlainText, :CriticMarkup, :TOC, :RemoteCode, :Code, :Macro, :Emoji, :Sanitize, :PlantUML, :Tags, :PandocBib, :Render]
       @filter_chain.delete(:Emoji) unless options.fetch :emoji, false
       @filter_chain.delete(:PandocBib) unless ::Gollum::MarkupRegisterUtils.using_pandoc?
+      @filter_chain.delete(:CriticMarkup) unless options.fetch :critic_markup, false
     end
 
     # Public: check whether the wiki's git repo exists on the filesystem.

--- a/test/filter/test_critic_markup.rb
+++ b/test/filter/test_critic_markup.rb
@@ -1,0 +1,64 @@
+# ~*~ encoding: utf-8 ~*~
+path = File.join(File.dirname(__FILE__), "..", "helper")
+require File.expand_path(path)
+
+context "Gollum::Filter::CriticMarkup" do
+  setup do
+    @filter = Gollum::Filter::CriticMarkup.new(Gollum::Markup.new(mock_page))
+  end
+
+  def filter(content)
+    @filter.process(@filter.extract(content))
+  end
+
+  # Examples from CriticMarkup spec: http://criticmarkup.com/spec.php
+
+  test "basic addition" do
+    assert_equal filter('Lorem ipsum dolor{++ sit++} amet'), 'Lorem ipsum dolor<ins> sit</ins> amet'
+  end
+  
+  test "paragraph addition" do
+    input = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum at orci magna. Phasellus augue justo, sodales eu pulvinar ac, vulputate eget nulla. Mauris massa sem, tempor sed cursus et, semper tincidunt lacus.{++
+
+++}Praesent sagittis, quam id egestas consequat, nisl orci vehicula libero, quis ultricies nulla magna interdum sem. Maecenas eget orci vitae eros accumsan mollis. Cras mi mi, rutrum id aliquam in, aliquet vitae tellus. Sed neque justo, cursus in commodo eget, facilisis eget nunc. Cras tincidunt auctor varius.'
+    expected_output = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum at orci magna. Phasellus augue justo, sodales eu pulvinar ac, vulputate eget nulla. Mauris massa sem, tempor sed cursus et, semper tincidunt lacus.
+
+<ins class='critic break'>&nbsp;</ins>
+
+Praesent sagittis, quam id egestas consequat, nisl orci vehicula libero, quis ultricies nulla magna interdum sem. Maecenas eget orci vitae eros accumsan mollis. Cras mi mi, rutrum id aliquam in, aliquet vitae tellus. Sed neque justo, cursus in commodo eget, facilisis eget nunc. Cras tincidunt auctor varius."
+    assert_equal filter(input), expected_output
+  end
+  
+  test "basic deletion" do
+    assert_equal filter('Lorem {-- ipsum--} dolor sit amet'), 'Lorem <del> ipsum</del> dolor sit amet'
+  end
+  
+  test "paragraph deletion" do
+    input = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum at orci magna. Phasellus augue justo, sodales eu pulvinar ac, vulputate eget nulla. Mauris massa sem, tempor sed cursus et, semper tincidunt lacus.{--
+
+--}Praesent sagittis, quam id egestas consequat, nisl orci vehicula libero, quis ultricies nulla magna interdum sem. Maecenas eget orci vitae eros accumsan mollis. Cras mi mi, rutrum id aliquam in, aliquet vitae tellus. Sed neque justo, cursus in commodo eget, facilisis eget nunc. Cras tincidunt auctor varius.'
+    expected_output = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum at orci magna. Phasellus augue justo, sodales eu pulvinar ac, vulputate eget nulla. Mauris massa sem, tempor sed cursus et, semper tincidunt lacus.<del>&nbsp;</del>Praesent sagittis, quam id egestas consequat, nisl orci vehicula libero, quis ultricies nulla magna interdum sem. Maecenas eget orci vitae eros accumsan mollis. Cras mi mi, rutrum id aliquam in, aliquet vitae tellus. Sed neque justo, cursus in commodo eget, facilisis eget nunc. Cras tincidunt auctor varius."
+    assert_equal filter(input), expected_output
+  end
+  
+  test "basic substitution" do
+    assert_equal filter('Lorem {~~hipsum~>ipsum~~} dolor sit amet'), 'Lorem <del>hipsum</del><ins>ipsum</ins> dolor sit amet'
+  end
+
+  test "basic comment" do
+    assert_equal filter('Lorem ipsum dolor sit amet.{>>This is a comment<<}'), "Lorem ipsum dolor sit amet.<span class='critic comment'>This is a comment</span>"
+  end
+  
+  test "basic highlight" do
+    input = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. {==Vestibulum at orci magna. Phasellus augue justo, sodales eu pulvinar ac, vulputate eget nulla.==}{>>confusing<<} Mauris massa sem, tempor sed cursus et, semper tincidunt lacus.'
+    expected_output = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. <mark>Vestibulum at orci magna. Phasellus augue justo, sodales eu pulvinar ac, vulputate eget nulla.</mark><span class='critic comment'>confusing</span> Mauris massa sem, tempor sed cursus et, semper tincidunt lacus."
+    assert_equal filter(input), expected_output
+  end
+  
+  test "all together" do
+    input = "Don't go around saying{-- to people that--} the world owes you a living. The world owes you nothing. It was here first. {~~One~>Only one~~} thing is impossible for God: To find {++any++} sense in any copyright law on the planet. {==Truth is stranger than fiction==}{>>strange but true<<}, but it is because Fiction is obliged to stick to possibilities; Truth isn't."
+    expected_output = "Don't go around saying<del> to people that</del> the world owes you a living. The world owes you nothing. It was here first. <del>One</del><ins>Only one</ins> thing is impossible for God: To find <ins>any</ins> sense in any copyright law on the planet. <mark>Truth is stranger than fiction</mark><span class='critic comment'>strange but true</span>, but it is because Fiction is obliged to stick to possibilities; Truth isn't."
+    assert_equal filter(input), expected_output
+  end
+  
+end


### PR DESCRIPTION
Requested in https://github.com/gollum/gollum/issues/1016. This PR adds basic support for [CriticMarkup](http://criticmarkup.com/) via a filter that implements the CriticMarkup [spec](http://criticmarkup.com/spec.php).

The filter is disabled by default. When it is enabled, it works gollum-wide (so for all valid pages with different markups). I don't think this breaks any of the existing syntax. If it does, we might have restrict usage to Markdown pages, but I would prefer it being available for all markups.

Currently, the rendering is pretty basic:

![screen shot 2018-11-05 at 14 33 30](https://user-images.githubusercontent.com/571173/48001127-f2d70a80-e107-11e8-95ae-38acb513a2e0.png)

The above syntax provides the following HTML.

```html
<p>Don't go around saying<del> to people that </del> the world owes you <del>a</del> living. The <ins>entire</ins> world owes you nothing. It was here first. <del>One</del><ins>Only one</ins> thing is impossible for <del>God</del><ins>Shazu</ins>: To find <ins>any</ins> sense in any copyright law on the planet. <mark>Truth is stranger than fiction</mark><span class="critic comment">true</span>, but it is because <mark>Fiction</mark><span class="critic comment"></span> is obliged to stick to possibilities; Truth isn't.</p>
```

This HTML is rendered as follows.

![screen shot 2018-11-05 at 14 33 10](https://user-images.githubusercontent.com/571173/48001160-04201700-e108-11e8-8508-9ee40b378638.png)


However, there is some CSS / JQuery magic that could be added to gollum to make it prettier.