### PR TITLE
Kramdown header location marking

### DIFF
--- a/lib/gollum-lib/markups.rb
+++ b/lib/gollum-lib/markups.rb
@@ -41,6 +41,16 @@ end
 
 include Gollum::MarkupRegisterUtils
 
+if gem_exists?('kramdown') then
+  require 'kramdown'
+  class Kramdown::Converter::HtmlSourcemap < Kramdown::Converter::Html
+    def convert_header(el, indent)
+      el.attr[:'data-sourcepos'] = el.options[:location]
+      super(el, indent)
+    end
+  end
+end
+
 module GitHub
   module Markup
     class Markdown < Implementation
@@ -56,7 +66,7 @@ end
 module Gollum
   class Markup
     GitHub::Markup::Markdown::MARKDOWN_GEMS['kramdown'] = proc { |content|
-        Kramdown::Document.new(content, :input => "GFM", :auto_ids => false, :math_engine => nil, :smart_quotes => ["'", "'", '"', '"'].map{|char| char.codepoints.first}).to_html
+      Kramdown::Document.new(content, :input => "GFM", :auto_ids => false, :math_engine => nil, :smart_quotes => ["'", "'", '"', '"'].map{|char| char.codepoints.first}).to_html_sourcemap
     }
     GitHub::Markup::Markdown::MARKDOWN_GEMS['pandoc-ruby'] = proc { |content|
         PandocRuby.convert(content, :s, :from => :markdown, :to => :html, :filter => 'pandoc-citeproc')

--- a/lib/gollum-lib/sanitization.rb
+++ b/lib/gollum-lib/sanitization.rb
@@ -223,6 +223,12 @@ module Gollum
     # Default whitelisted attributes.
     ATTRIBUTES = ({
         'a'   => ['href'],
+        'h1'  => ['data-sourcepos'],
+        'h2'  => ['data-sourcepos'],
+        'h3'  => ['data-sourcepos'],
+        'h4'  => ['data-sourcepos'],
+        'h5'  => ['data-sourcepos'],
+        'h6'  => ['data-sourcepos'],
         'img' => ['src'],
         :all  => ['abbr', 'accept', 'accept-charset',
                   'accesskey', 'action', 'align', 'alt', 'axis',


### PR DESCRIPTION
To implement a clean way of editing per section (see https://github.com/gollum/gollum/issues/1000), we need the rendering gem to support sourcemaps (i.e., outputting the position in the markup source of a rendered element in the html), minimally for header elements.

`commonmarker` has [in-built sourcemapping](https://github.com/gjtorikian/commonmarker#passing-options), but for gollum I think we want to stick with `kramdown` as a default for now (`commonmarker` uses c-extensions). So:

This experimental PR overrides the default `kramdown` converter to output the position (linenumber) of a header element in the `data-sourcepos` attribute of the `hX` element. Example output (taken from the frontend):
```
 <h1 data-sourcepos="1"><a class="anchor" id="bilbo-baggins" href="#bilbo-baggins"><i class="fa fa-link"></i></a>Bilbo Baggins</h1>
```

It is slightly hackish, in so far as updates to `kramdown` might break this -- but the changes required are fairly minimal, as you can see. Maybe it wouldn't cause too much trouble, assuming that `kramdown` doesn't end up breaking SemVer. But do let me know if you think it's just too much of a hack.

In the frontend, we could simply pass the value of the `data-sourcepos` attribute along to the edit view, if it exits, and make the editor jump to that line in the source.

Complication: of course, the `render` filter is last in the filter chains. So if previous filters extract parts of the markup source, the line numbers generated by kramdown may be incorrect. Could we make it a policy for filters to always substitute back the same amount of lines as they extract?

`commonmarker` also stores the source position in the `data-sourcepos` attribute, so we could enable this when `commonmarker` is used and get the same effect in the frontend. Although the output looks slightly different:
```ruby
2.4.1 :001 > require 'commonmarker'
 => true 
2.4.1 :002 > CommonMarker.render_html("\"'Shelob' is my name.\"", [:HARDBREAKS, :SOURCEPOS])
 => "<p data-sourcepos=\"1:1-1:22\">&quot;'Shelob' is my name.&quot;</p>\n" 
```
(We only need the starting line number)