### PR TITLE
Remove useless code from markup.rb

### DIFF
--- a/lib/gollum-lib/markup.rb
+++ b/lib/gollum-lib/markup.rb
@@ -152,13 +152,6 @@ module Gollum
         Gollum::Filter.const_get(filter_sym).new(self)
       end
 
-      # Since the last 'extract' action in our chain *should* be the markup
-      # to HTML converter, we now have HTML which we can parse and yield, for
-      # anyone who wants it
-      if block_given?
-        yield Nokogiri::HTML::DocumentFragment.parse(data)
-      end
-
       process_chain data, filter_chain
     end
 


### PR DESCRIPTION
This looks like a remainder of days long gone. It says it's expecting `data` to be the result of the rendering operation, but the filter chain hasn't even been executed yet. Moreover, the `render` method doesn't take an optional block, so we'll never actually yield. Probably someone forgot to remove this piece of code when the actual execution of the filter chain was moved to the `process_chain` method. Right now it's not doing anything.