### PR TITLE
Do not include ancestry in anchors. Resolves #167

### DIFF
--- a/lib/gollum-lib/filter/toc.rb
+++ b/lib/gollum-lib/filter/toc.rb
@@ -70,7 +70,7 @@ class Gollum::Filter::TOC < Gollum::Filter
   # Prefixes duplicate anchors with an index
   def generate_anchor_name(header)
     name = header.content
-    level = header.name.gsub(/[hH]/, '').to_i
+    level = header.name[1..-1].to_i
 
     # normalize the header name
     name.gsub!(/[^\d\w\u00C0-\u1FFF\u2C00-\uD7FF]/, "-")
@@ -79,15 +79,13 @@ class Gollum::Filter::TOC < Gollum::Filter
     name.gsub!(/-$/, "")
     name.downcase!
 
-    @current_ancestors[level - 1] = name
-    @current_ancestors = @current_ancestors.take(level)
-    anchor_name = @current_ancestors.compact.join("_")
+    #@current_ancestors[level - 1] = name
+    #@current_ancestors = @current_ancestors.take(level)
+    #anchor_name = @current_ancestors.compact.join("_")
 
     # Ensure duplicate anchors have a unique prefix or the toc will break
-    index = increment_anchor_index(anchor_name)
-    anchor_name = "#{index}-#{anchor_name}" unless index.zero? # if the index is zero this name is unique
-
-    anchor_name
+    index = increment_anchor_index(name)
+    index.zero? ? name : "#{name}-#{index}"
   end
 
   # Creates an anchor element with the given name and adds it before

--- a/lib/gollum-lib/filter/toc.rb
+++ b/lib/gollum-lib/filter/toc.rb
@@ -79,10 +79,6 @@ class Gollum::Filter::TOC < Gollum::Filter
     name.gsub!(/-$/, "")
     name.downcase!
 
-    #@current_ancestors[level - 1] = name
-    #@current_ancestors = @current_ancestors.take(level)
-    #anchor_name = @current_ancestors.compact.join("_")
-
     # Ensure duplicate anchors have a unique prefix or the toc will break
     index = increment_anchor_index(name)
     index.zero? ? name : "#{name}-#{index}"

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -994,7 +994,7 @@ __TOC__
 # Summary
     MARKDOWN
 
-    output = "<p><strong>TOC</strong></p>\n\n<h1><a class=\"anchor\" id=\"summary\" href=\"#summary\"><i class=\"fa fa-link\"></i></a>Summary</h1>\n\n<h1><a class=\"anchor\" id=\"1-summary\" href=\"#1-summary\"><i class=\"fa fa-link\"></i></a>Summary</h1>"
+    output = "<p><strong>TOC</strong></p>\n\n<h1><a class=\"anchor\" id=\"summary\" href=\"#summary\"><i class=\"fa fa-link\"></i></a>Summary</h1>\n\n<h1><a class=\"anchor\" id=\"summary-1\" href=\"#summary-1\"><i class=\"fa fa-link\"></i></a>Summary</h1>"
     compare(content, output, :markdown)
   end
 
@@ -1007,20 +1007,24 @@ __TOC__
 # Summary !@$#%^&*() stuff
     MARKDOWN
 
-    output = "<p><strong>TOC</strong></p>\n\n<h1><a class=\"anchor\" id=\"summary-stuff\" href=\"#summary-stuff\"><i class=\"fa fa-link\"></i></a>Summary '\"' stuff</h1>\n\n<h1><a class=\"anchor\" id=\"1-summary-stuff\" href=\"#1-summary-stuff\"><i class=\"fa fa-link\"></i></a>Summary !@$#%^&*() stuff</h1>"
+    output = "<p><strong>TOC</strong></p>\n\n<h1><a class=\"anchor\" id=\"summary-stuff\" href=\"#summary-stuff\"><i class=\"fa fa-link\"></i></a>Summary '\"' stuff</h1>\n\n<h1><a class=\"anchor\" id=\"summary-stuff-1\" href=\"#summary-stuff-1\"><i class=\"fa fa-link\"></i></a>Summary !@$#%^&*() stuff</h1>"
     compare(content, output, :markdown)
   end
 
-  test 'anchor names contain the ancestor' do
+  test 'anchor names are unique' do
     content = <<-MARKDOWN
 __TOC__
 
 # Summary
 
 ## Horse
+
+# Summary
+
+### Horse
     MARKDOWN
 
-    output = "<p><strong>TOC</strong></p>\n\n<h1><a class=\"anchor\" id=\"summary\" href=\"#summary\"><i class=\"fa fa-link\"></i></a>Summary</h1>\n\n<h2><a class=\"anchor\" id=\"summary_horse\" href=\"#summary_horse\"><i class=\"fa fa-link\"></i></a>Horse</h1>"
+    output = "<p><strong>TOC</strong></p>\n\n<h1><a class=\"anchor\" id=\"summary\" href=\"#summary\"><i class=\"fa fa-link\"></i></a>Summary</h1>\n\n<h2><a class=\"anchor\" id=\"horse\" href=\"#horse\"><i class=\"fa fa-link\"></i></a>Horse</h2>\n<h1><a class=\"anchor\" id=\"summary-1\" href=\"#summary-1\"><i class=\"fa fa-link\"></i></a>Summary</h1>\n\n<h3><a class=\"anchor\" id=\"horse-1\" href=\"#horse-1\"><i class=\"fa fa-link\"></i></a>Horse</h3>"
     compare(content, output, :markdown)
   end
 

--- a/test/test_wiki.rb
+++ b/test/test_wiki.rb
@@ -145,6 +145,8 @@ context "Wiki TOC" do
 
 ## Denethor
 
+### Ecthelion
+
 ### Boromir
 
 ### Faramir
@@ -152,9 +154,10 @@ context "Wiki TOC" do
 
     formatted = <<-HTML
 <h1><a class="anchor" id="ecthelion" href="#ecthelion"><i class="fa fa-link"></i></a>Ecthelion</h1>
-<h2><a class="anchor" id="ecthelion_denethor" href="#ecthelion_denethor"><i class="fa fa-link"></i></a>Denethor</h2>
-<h3><a class="anchor" id="ecthelion_denethor_boromir" href="#ecthelion_denethor_boromir"><i class="fa fa-link"></i></a>Boromir</h3>
-<h3><a class="anchor" id="ecthelion_denethor_faramir" href="#ecthelion_denethor_faramir"><i class="fa fa-link"></i></a>Faramir</h3>
+<h2><a class="anchor" id="denethor" href="#denethor"><i class="fa fa-link"></i></a>Denethor</h2>
+<h3><a class="anchor" id="ecthelion-1" href="#ecthelion-1"><i class="fa fa-link"></i></a>Ecthelion</h3>
+<h3><a class="anchor" id="boromir" href="#boromir"><i class="fa fa-link"></i></a>Boromir</h3>
+<h3><a class="anchor" id="faramir" href="#faramir"><i class="fa fa-link"></i></a>Faramir</h3>
     HTML
 
     page_level0 = @wiki.preview_page("Test", "[[_TOC_ | levels=0]] \n\n" + content, :markdown)
@@ -177,7 +180,7 @@ context "Wiki TOC" do
 <p><div class="toc">
 <div class="toc-title">Table of Contents</div>
 <ul><li><a href="#ecthelion">Ecthelion</a>
-<ul><li><a href="#ecthelion_denethor">Denethor</a></li></ul>
+<ul><li><a href="#denethor">Denethor</a></li></ul>
 </li></ul>
 </div></p>
     HTML
@@ -193,10 +196,11 @@ context "Wiki TOC" do
   <li>
     <a href="#ecthelion">Ecthelion</a>
     <ul>
-      <li><a href="#ecthelion_denethor">Denethor</a>
+      <li><a href="#denethor">Denethor</a>
     <ul>
-      <li><a href="#ecthelion_denethor_boromir">Boromir</a></li>
-      <li><a href="#ecthelion_denethor_faramir">Faramir</a></li>
+      <li><a href="#ecthelion-1">Ecthelion</a></li>
+      <li><a href="#boromir">Boromir</a></li>
+      <li><a href="#faramir">Faramir</a></li>
     </ul>
   </li></ul>
 </li></ul>


### PR DESCRIPTION
#167 rightly complains that anchors get too long because the full header-ancestry is included in them (so end up e.g. with `Manual/prefs#preferences_editor-preferences_smart-editing_configuring-word-or-character-wrap`). https://github.com/gollum/gollum/issues/1261 complains that github and gollum use different schemes to generate anchors.

This PR solves the first issue by conforming the way we generate anchors to GitHub's scheme:
```
# Ecthelion

## Boromir

## Faramir

# Boromir

## Ecthelion
```
...generates these anchors:
```
#ecthelion
#boromir
#faramir
#boromir-1
#ecthelion-1 
```

As an added advantage, this somewhat simplifies the logic in the TOC filter.

- [ ] Update release notes