### PR TITLE
Make normalization of files in Committer#add_to_index optional for handling binary files correctly.

### DIFF
--- a/lib/gollum-lib/committer.rb
+++ b/lib/gollum-lib/committer.rb
@@ -82,7 +82,7 @@ module Gollum
     # This way, pages are not inadvertently overwritten.
     #
     # Returns nothing (modifies the Index in place).
-    def add_to_index(dir, name, format, data)
+    def add_to_index(dir, name, format, data, options = {})
       path = @wiki.page_file_name(name, format)
 
       dir  = '/' if dir.strip.empty?
@@ -116,11 +116,13 @@ module Gollum
         fullpath = fullpath.force_encoding('ascii-8bit') if fullpath.respond_to?(:force_encoding)
       end
 
-      begin
-        data = @wiki.normalize(data)
-      rescue ArgumentError => err
-        # Swallow errors that arise from data being binary
-        raise err unless err.message.include?('invalid byte sequence')
+      unless options[:normalize] == false
+        begin
+          data = @wiki.normalize(data)
+        rescue ArgumentError => err
+          # Swallow errors that arise from data being binary
+          raise err unless err.message.include?('invalid byte sequence')
+        end
       end
       index.add(fullpath, data)
     end


### PR DESCRIPTION
Related to https://github.com/gollum/gollum/issues/1306.

This way, we can let callers of `add_to_index` decide whether to disable normalization of files. This is particularly useful for uploaded files such as images or pdf documents. 

The rationale for this implementation is that most `add_to_index` operations will be text-based, which makes normalization as the default sensible. We wouldn't want to test each page for whether it is binary or not. However, with uploaded files, we want to be able to skip the normalization step.