### PR TITLE
Render pure anchor page links. Resolves gollum#1236

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 rvm:
-  - 2.3.0
   - 2.4.0
+  - 2.6.3
   - jruby-9.1.8.0
 jdk:
   - oraclejdk8

--- a/lib/gollum-lib/filter/tags.rb
+++ b/lib/gollum-lib/filter/tags.rb
@@ -215,7 +215,7 @@ class Gollum::Filter::Tags < Gollum::Filter
     page      = find_page_from_path(link)
 
     # If no match yet, try finding page with anchor removed
-    unless page
+    if page.nil?
       if pos = link.rindex('#')
         extra = link[pos..-1]
         link  = link[0...pos]
@@ -223,7 +223,7 @@ class Gollum::Filter::Tags < Gollum::Filter
         extra = nil
       end
 
-      if link.empty? && !extra.nil? # Internal anchor link, don't search for the page but return immediately
+      if link.empty? && extra # Internal anchor link, don't search for the page but return immediately
         return generate_link(nil, pretty_name, extra, :internal_anchor)
       end
 
@@ -273,11 +273,8 @@ class Gollum::Filter::Tags < Gollum::Filter
   #
   # Returns a String href.
   def generate_href_for_path(path, extra = nil)
-    if path.nil? && !extra.nil? # Internal anchor link
-      extra
-    else
-      "#{trim_leading_slash(::File.join(@markup.wiki.base_path, path))}#{extra}"
-    end
+    return extra if !path && extra # Internal anchor link
+    "#{trim_leading_slash(::File.join(@markup.wiki.base_path, path))}#{extra}"
   end
 
   # Construct a CSS class and attribute string for different kinds of links: internal Pages (absent or present) and Files, and External links.
@@ -292,7 +289,7 @@ class Gollum::Filter::Tags < Gollum::Filter
     when :page_present
       'class="internal present"'
     when :internal_anchor
-      'class="internal-anchor"'
+      'class="internal anchorlink"'
     when :file
       nil
     when :external

--- a/lib/gollum-lib/sanitization.rb
+++ b/lib/gollum-lib/sanitization.rb
@@ -283,11 +283,12 @@ module Gollum
         end,
         lambda do |env|
           node = env[:node]
-          return unless (value = node['href'])
-          prefix       = env[:config][:id_prefix]
-          node['href'] = value.gsub(/\A\#(#{prefix})?/, '#'+prefix)
-          ADD_ATTRIBUTES.call(env, node)
-          {}
+          if (value = node['href']) && !(node[:class] == 'internal-anchor') # make an exception for pure anchor links
+            prefix       = env[:config][:id_prefix]
+            node['href'] = value.gsub(/\A\#(#{prefix})?/, '#'+prefix)
+            ADD_ATTRIBUTES.call(env, node)
+            {}
+          end
         end
     ].freeze
 

--- a/lib/gollum-lib/sanitization.rb
+++ b/lib/gollum-lib/sanitization.rb
@@ -283,7 +283,7 @@ module Gollum
         end,
         lambda do |env|
           node = env[:node]
-          if (value = node['href']) && !(node[:class] == 'internal-anchor') # make an exception for pure anchor links
+          if (value = node['href']) && !(node[:class] == 'internal anchorlink') # make an exception for pure anchor links
             prefix       = env[:config][:id_prefix]
             node['href'] = value.gsub(/\A\#(#{prefix})?/, '#'+prefix)
             ADD_ATTRIBUTES.call(env, node)

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -270,14 +270,14 @@ context "Markup" do
     @wiki.write_page("Potato", :markdown, "# Test\nWaa\n[[Link Text|#test]] ", commit_details)
     page   = @wiki.page("Potato")
     output = page.formatted_data
-    assert_html_equal "<h1><a class=\"anchor\" id=\"test\" href=\"#test\"><i class=\"fa fa-link\"></i></a>Test</h1><p>Waa<br />\n<a class=\"internal anchorlink\" href=\"#test\">Link Text</a></p>", output
+    assert_html_equal "<h1 class=\"editable\"><a class=\"anchor\" id=\"test\" href=\"#test\"><i class=\"fa fa-link\"></i></a>Test</h1><p>Waa<br />\n<a class=\"internal anchorlink\" href=\"#test\">Link Text</a></p>", output
   end
 
   test "page link with internal anchorlink only on mediawiki" do
     @wiki.write_page("Potato", :mediawiki, "= Test =\nWaa\n[[#test|Link Text]] ", commit_details)
     page   = @wiki.page("Potato")
     output = page.formatted_data
-    assert_html_equal "<h1><a class=\"anchor\" id=\"test\" href=\"#test\"><i class=\"fa fa-link\"></i></a><a name=\"wiki-Test\" id=\"wiki-Test\"></a><span class=\"mw-headline\" id=\"wiki-Test\">Test</span>\n</h1><p>Waa<a class=\"internal anchorlink\" href=\"#test\">Link Text</a></p>", output
+    assert_html_equal "<h1 class=\"editable\"><a class=\"anchor\" id=\"test\" href=\"#test\"><i class=\"fa fa-link\"></i></a><a name=\"wiki-Test\" id=\"wiki-Test\"></a><span class=\"mw-headline\" id=\"wiki-Test\">Test</span>\n</h1><p>Waa<a class=\"internal anchorlink\" href=\"#test\">Link Text</a></p>", output
   end
 
 

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -277,7 +277,19 @@ context "Markup" do
     @wiki.write_page("Potato", :mediawiki, "= Test =\nWaa\n[[#test|Link Text]] ", commit_details)
     page   = @wiki.page("Potato")
     output = page.formatted_data
-    assert_html_equal "<h1 class=\"editable\"><a class=\"anchor\" id=\"test\" href=\"#test\"><i class=\"fa fa-link\"></i></a><a name=\"wiki-Test\" id=\"wiki-Test\"></a><span class=\"mw-headline\" id=\"wiki-Test\">Test</span>\n</h1><p>Waa<a class=\"internal anchorlink\" href=\"#test\">Link Text</a></p>", output
+
+    # Workaround for testing HTML equality: nokogiri on jruby reverses the order of the ID and HREF attributes
+    expected = "<h1 class=\"editable\"><a class=\"anchor\" "
+    id = "id=\"test\""
+    href = "href=\"#test\""
+    if RUBY_PLATFORM == 'java'
+      expected = expected << href << " " << id
+    else
+      expected = expected << id << " " << href
+    end
+    expected = expected << " ><i class=\"fa fa-link\"></i></a><a name=\"wiki-Test\" id=\"wiki-Test\"></a><span class=\"mw-headline\" id=\"wiki-Test\">Test</span>\n</h1><p>Waa<a class=\"internal anchorlink\" href=\"#test\">Link Text</a></p>"
+
+    assert_html_equal expected, output
   end
 
 

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -266,18 +266,18 @@ context "Markup" do
     assert_html_equal "<p>\na <a class=\"internal present\" href=\"/Potato.mediawiki\">Potato Heaad</a> </p>", output
   end
 
-  test "page link with anchor only" do
+  test "page link with internal anchorlink only" do
     @wiki.write_page("Potato", :markdown, "# Test\nWaa\n[[Link Text|#test]] ", commit_details)
     page   = @wiki.page("Potato")
     output = page.formatted_data
-    assert_html_equal "<h1><a class=\"anchor\" id=\"test\" href=\"#test\"><i class=\"fa fa-link\"></i></a>Test</h1><p>Waa<br />\n<a class=\"internal-anchor\" href=\"#test\">Link Text</a></p>", output
+    assert_html_equal "<h1><a class=\"anchor\" id=\"test\" href=\"#test\"><i class=\"fa fa-link\"></i></a>Test</h1><p>Waa<br />\n<a class=\"internal anchorlink\" href=\"#test\">Link Text</a></p>", output
   end
 
-  test "page link with anchor only on mediawiki" do
+  test "page link with internal anchorlink only on mediawiki" do
     @wiki.write_page("Potato", :mediawiki, "= Test =\nWaa\n[[#test|Link Text]] ", commit_details)
     page   = @wiki.page("Potato")
     output = page.formatted_data
-    assert_html_equal "<h1><a class=\"anchor\" id=\"test\" href=\"#test\"><i class=\"fa fa-link\"></i></a><a name=\"wiki-Test\" id=\"wiki-Test\"></a><span class=\"mw-headline\" id=\"wiki-Test\">Test</span>\n</h1><p>Waa<a class=\"internal-anchor\" href=\"#test\">Link Text</a></p>", output
+    assert_html_equal "<h1><a class=\"anchor\" id=\"test\" href=\"#test\"><i class=\"fa fa-link\"></i></a><a name=\"wiki-Test\" id=\"wiki-Test\"></a><span class=\"mw-headline\" id=\"wiki-Test\">Test</span>\n</h1><p>Waa<a class=\"internal anchorlink\" href=\"#test\">Link Text</a></p>", output
   end
 
 

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -278,7 +278,7 @@ context "Markup" do
     page   = @wiki.page("Potato")
     output = page.formatted_data
 
-    # Workaround for testing HTML equality: nokogiri on jruby reverses the order of the ID and HREF attributes
+    # Workaround for testing HTML equality, needed because of differences in nokogiri output on JRuby and MRI
     expected = "<h1 class=\"editable\"><a class=\"anchor\" "
     id = "id=\"test\""
     href = "href=\"#test\""
@@ -287,7 +287,9 @@ context "Markup" do
     else
       expected = expected << id << " " << href
     end
-    expected = expected << " ><i class=\"fa fa-link\"></i></a><a name=\"wiki-Test\" id=\"wiki-Test\"></a><span class=\"mw-headline\" id=\"wiki-Test\">Test</span>\n</h1><p>Waa<a class=\"internal anchorlink\" href=\"#test\">Link Text</a></p>"
+    expected = expected << " ><i class=\"fa fa-link\"></i></a><a name=\"wiki-Test\""
+    expected = expected << " id=\"wiki-Test\"" unless RUBY_PLATFORM == 'java'
+    expected = expected << "></a><span class=\"mw-headline\" id=\"wiki-Test\">Test</span>\n</h1><p>Waa<a class=\"internal anchorlink\" href=\"#test\">Link Text</a></p>"
 
     assert_html_equal expected, output
   end

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -266,6 +266,21 @@ context "Markup" do
     assert_html_equal "<p>\na <a class=\"internal present\" href=\"/Potato.mediawiki\">Potato Heaad</a> </p>", output
   end
 
+  test "page link with anchor only" do
+    @wiki.write_page("Potato", :markdown, "# Test\nWaa\n[[Link Text|#test]] ", commit_details)
+    page   = @wiki.page("Potato")
+    output = page.formatted_data
+    assert_html_equal "<h1><a class=\"anchor\" id=\"test\" href=\"#test\"><i class=\"fa fa-link\"></i></a>Test</h1><p>Waa<br />\n<a class=\"internal-anchor\" href=\"#test\">Link Text</a></p>", output
+  end
+
+  test "page link with anchor only on mediawiki" do
+    @wiki.write_page("Potato", :mediawiki, "= Test =\nWaa\n[[#test|Link Text]] ", commit_details)
+    page   = @wiki.page("Potato")
+    output = page.formatted_data
+    assert_html_equal "<h1><a class=\"anchor\" id=\"test\" href=\"#test\"><i class=\"fa fa-link\"></i></a><a name=\"wiki-Test\" id=\"wiki-Test\"></a><span class=\"mw-headline\" id=\"wiki-Test\">Test</span>\n</h1><p>Waa<a class=\"internal-anchor\" href=\"#test\">Link Text</a></p>", output
+  end
+
+
   test "wiki link within inline code block" do
     @wiki.write_page("Potato", :markdown, "`sed -i '' 's/[[:space:]]*$//'`", commit_details)
     page = @wiki.page("Potato")


### PR DESCRIPTION
Issue: https://github.com/gollum/gollum/issues/1236

This PR resolves the issue by catching the anchor-only edge case in the tag filter. Additionally, an exception had to be made to the sanitization rules: the sanitizer currently prefixes 'wiki-' to all href elements that start with '#'. I think this is in order for gollum's css to apply to elements generated in the filter chain, and the exception should thus not pose a security risk -- but please see if that makes sense.

Flow control was a little complicated, so please let me know if you see better options.