### PR TITLE
Normalize filter chain sub patterns. Mark headers in source as editable.

### DIFF
--- a/lib/gollum-lib/filter.rb
+++ b/lib/gollum-lib/filter.rb
@@ -47,6 +47,8 @@ module Gollum
   class Filter
     include Gollum::Helpers
 
+    PLACEHOLDER_PATTERN = /%(\S+)%.+=\1=/
+
     # Setup the object.  Sets `@markup` to be the instance of Gollum::Markup that
     # is running this filter chain, and sets `@map` to be an empty hash (for use
     # in your extract/process operations).
@@ -63,6 +65,14 @@ module Gollum
     def process(data)
       raise RuntimeError,
             "#{self.class} has not implemented ##process!"
+    end
+
+    def open_pattern
+      @open_pattern ||= "%#{self.class.to_s.split('::').last}%"
+    end
+
+    def close_pattern
+      @close_pattern ||= "=#{self.class.to_s.split('::').last}="
     end
 
     protected

--- a/lib/gollum-lib/filter.rb
+++ b/lib/gollum-lib/filter.rb
@@ -55,7 +55,11 @@ module Gollum
     def initialize(markup)
       @markup = markup
       @map    = {}
+      @open_pattern = "%#{self.class.to_s.split('::').last}%"
+      @close_pattern = "=#{self.class.to_s.split('::').last}="
     end
+
+    attr_reader :open_pattern, :close_pattern
 
     def extract(data)
       raise RuntimeError,
@@ -65,14 +69,6 @@ module Gollum
     def process(data)
       raise RuntimeError,
             "#{self.class} has not implemented ##process!"
-    end
-
-    def open_pattern
-      @open_pattern ||= "%#{self.class.to_s.split('::').last}%"
-    end
-
-    def close_pattern
-      @close_pattern ||= "=#{self.class.to_s.split('::').last}="
     end
 
     protected

--- a/lib/gollum-lib/filter/code.rb
+++ b/lib/gollum-lib/filter/code.rb
@@ -133,7 +133,7 @@ class Gollum::Filter::Code < Gollum::Filter
 
   def cache_codeblock(language, code, indent = "")
     language = language.to_s.empty? ? nil : language
-    id = Digest::SHA1.hexdigest("#{language}.#{code}")
+    id = "#{open_pattern}#{Digest::SHA1.hexdigest("#{language}.#{code}")}#{close_pattern}"
     cached = @markup.check_cache(:code, id)
     @map[id] = cached ?
       { :output => cached } :

--- a/lib/gollum-lib/filter/critic_markup.rb
+++ b/lib/gollum-lib/filter/critic_markup.rb
@@ -16,13 +16,10 @@ class Gollum::Filter::CriticMarkup < Gollum::Filter
   HIGHLIGHT_PATTERN     = %r|{\=\=(?<content>.*?)[ \t]*(\[(.*?)\])?[ \t]*\=\=\}{>>(?<comment>.*?)<<}|m
   COMMENT_PATTERN       = %r|{>>(?<content>.*?)<<}|m
 
-  PROCESS_PATTERN       = /(?<placeholder>=CRITIC\h{40})/
-
-
   def extract(data)
     data.gsub! ADDITION_PATTERN do
       content = $~[:content]
-      placeholder = "=CRITIC" + Digest::SHA1.hexdigest("#{content}#{@map.size}")
+      placeholder = generate_placeholder("#{content}#{@map.size}")
     	# Is there a new paragraph followed by new text
       if content.start_with?("\n\n") && content != "\n\n"
         html = "\n\n<ins class='critic break'>&nbsp;</ins>\n\n<ins>#{content.gsub('\n', ' ')}</ins>"
@@ -41,7 +38,7 @@ class Gollum::Filter::CriticMarkup < Gollum::Filter
     
     data.gsub! DELETION_PATTERN do
       content = $~[:content]
-      placeholder = "=CRITIC" + Digest::SHA1.hexdigest("#{content}#{@map.size}")
+      placeholder = generate_placeholder("#{content}#{@map.size}")
       if content == "\n\n"
         html = "<del>&nbsp;</del>"
       else
@@ -54,7 +51,7 @@ class Gollum::Filter::CriticMarkup < Gollum::Filter
     data.gsub! SUBSTITUTION_PATTERN do
       oldcontent = $~[:oldcontent]
       newcontent = $~[:newcontent]
-      placeholder = "=CRITIC" + Digest::SHA1.hexdigest("#{oldcontent}#{newcontent}#{@map.size}")
+      placeholder = generate_placeholder("#{oldcontent}#{newcontent}#{@map.size}")
       html = "<del>#{oldcontent}</del><ins>#{newcontent}</ins>"
       @map[placeholder] = html
       placeholder
@@ -63,7 +60,7 @@ class Gollum::Filter::CriticMarkup < Gollum::Filter
     data.gsub! HIGHLIGHT_PATTERN do
       content = $~[:content]
       comment = $~[:comment]
-      placeholder = "=CRITIC" + Digest::SHA1.hexdigest("#{content}#{@map.size}")
+      placeholder = generate_placeholder("#{content}#{@map.size}")
       html = "<mark>#{content}</mark><span class='critic comment'>#{comment}</span>"
       @map[placeholder] = html
       placeholder
@@ -71,7 +68,7 @@ class Gollum::Filter::CriticMarkup < Gollum::Filter
     
     data.gsub! COMMENT_PATTERN do
       content = $~[:content]
-      placeholder = "=CRITIC" + Digest::SHA1.hexdigest("#{content}#{@map.size}")
+      placeholder = generate_placeholder("#{content}#{@map.size}")
       html = "<span class='critic comment'>#{content}</span>"
       @map[placeholder] = html
       placeholder
@@ -80,14 +77,21 @@ class Gollum::Filter::CriticMarkup < Gollum::Filter
     data
   end
 
-
-
   def process(data)
-    data.gsub! PROCESS_PATTERN do 
+    data.gsub! process_pattern do 
       @map[$~[:placeholder]]
     end
     data
   end
 
+  private
+
+  def process_pattern
+    /(?<placeholder>#{open_pattern}\h{40}#{close_pattern})/
+  end
+
+  def generate_placeholder(content)
+    "#{open_pattern}#{Digest::SHA1.hexdigest(content)}#{close_pattern}"
+  end
 
 end

--- a/lib/gollum-lib/filter/emoji.rb
+++ b/lib/gollum-lib/filter/emoji.rb
@@ -14,17 +14,11 @@ class Gollum::Filter::Emoji < Gollum::Filter
     (?!\]{^2})
   }ix
 
-  PROCESS_PATTERN = %r{
-    =EEMMOOJJII=
-    (?<name>[\w-]+)
-    =IIJJOOMMEE=
-  }ix
-
   def extract(data)
     data.gsub! EXTRACT_PATTERN do
       case
         when $~[:escape] then $&[1..-1]
-        when emoji_exists?($~[:name]) then "=EEMMOOJJII=#{$~[:name]}=IIJJOOMMEE="
+        when emoji_exists?($~[:name]) then "#{open_pattern}#{$~[:name]}#{close_pattern}"
         else $&
       end
     end
@@ -32,11 +26,19 @@ class Gollum::Filter::Emoji < Gollum::Filter
   end
 
   def process(data)
-    data.gsub! PROCESS_PATTERN, %q(<img src="/emoji/\k<name>" alt="\k<name>" class="emoji">)
+    data.gsub! process_pattern, %q(<img src="/emoji/\k<name>" alt="\k<name>" class="emoji">)
     data
   end
 
   private
+
+  def process_pattern
+    %r{
+    #{open_pattern}
+    (?<name>[\w-]+)
+    #{close_pattern}
+  }ix
+  end
 
   def emoji_exists?(name)
     @index ||= Gemojione::Index.new

--- a/lib/gollum-lib/filter/macro.rb
+++ b/lib/gollum-lib/filter/macro.rb
@@ -12,7 +12,7 @@ class Gollum::Filter::Macro < Gollum::Filter
 
     data.gsub(/('?)\<\<\s*([A-Z][A-Za-z0-9]*)\s*\(#{arg_list}\)\s*\>\>/) do
       next CGI.escape_html($&[1..-1]) unless Regexp.last_match[1].empty?
-      id = Digest::SHA1.hexdigest(Regexp.last_match[2] + Regexp.last_match[3])
+      id = "#{open_pattern}#{Digest::SHA1.hexdigest(Regexp.last_match[2] + Regexp.last_match[3])}#{close_pattern}"
       macro = Regexp.last_match[2]
       argstr = Regexp.last_match[3]
       args = []

--- a/lib/gollum-lib/filter/plantuml.rb
+++ b/lib/gollum-lib/filter/plantuml.rb
@@ -70,7 +70,7 @@ class Gollum::Filter::PlantUML < Gollum::Filter
   # placeholders.
   def extract(data)
     data.gsub(/(@startuml\r?\n.+?\r?\n@enduml\r?$)/m) do
-      id       = Digest::SHA1.hexdigest($1)
+      id       = "#{open_pattern}#{Digest::SHA1.hexdigest($1)}#{close_pattern}"
       @map[id] = { :code => $1 }
       id
     end

--- a/lib/gollum-lib/filter/render.rb
+++ b/lib/gollum-lib/filter/render.rb
@@ -15,6 +15,25 @@ class Gollum::Filter::Render < Gollum::Filter
   end
 
   def process(data)
+    data = add_editable_header_class(data)
     data
   end
+
+  private
+
+  def add_editable_header_class(data)
+    doc = Nokogiri::HTML::DocumentFragment.parse(data)
+    doc.css('h1,h2,h3,h4,h5,h6').each_with_index do |header, i|
+      next if header.content.empty?
+      next if header.inner_html.match(PLACEHOLDER_PATTERN)
+      klass = header['class']
+      if klass
+        header['class'] = klass << ' editable'
+      else
+        header['class'] = 'editable'
+      end
+    end
+    doc.to_xml(@markup.to_xml_opts)
+  end
+
 end

--- a/lib/gollum-lib/filter/tags.rb
+++ b/lib/gollum-lib/filter/tags.rb
@@ -34,7 +34,7 @@ class Gollum::Filter::Tags < Gollum::Filter
     doc.traverse do |node|
       if node.text? then
         content = node.content
-        content.gsub!(/TAG[a-f0-9]+TAG/) do |id|
+        content.gsub!(%r{#{open_pattern}[a-f0-9]+#{close_pattern}}) do |id|
           if (tag = @map[id]) then
             if is_preformatted?(node) then
               "[[#{tag}]]"
@@ -56,7 +56,7 @@ class Gollum::Filter::Tags < Gollum::Filter
   INCLUDE_TAG = 'include:'
 
   def register_tag(tag)
-    id       = "TAG#{Digest::SHA1.hexdigest(tag)}TAG"
+    id       = "#{open_pattern}#{Digest::SHA1.hexdigest(tag)}#{close_pattern}"
     @map[id] = tag
     id
   end

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -957,13 +957,13 @@ np.array([[2,2],[1,3]],np.float)
 
   test "id with prefix ok" do
     content = "h2(example#wiki-foo). xxxx"
-    output  = "<h2 class=\"example\" id=\"wiki-foo\"><a class=\"anchor\" id=\"xxxx\" href=\"#xxxx\"><i class=\"fa fa-link\"></i></a>xxxx</h2>"
+    output  = "<h2 class=\"example editable\" id=\"wiki-foo\"><a class=\"anchor\" id=\"xxxx\" href=\"#xxxx\"><i class=\"fa fa-link\"></i></a>xxxx</h2>"
     compare(content, output, :textile)
   end
 
   test "id prefix added" do
     content = "h2(#foo). xxxx[1]\n\nfn1.footnote"
-    output  = "<h2 id=\"wiki-foo\"><a class=\"anchor\" id=\"xxxx1\" href=\"#xxxx1\"><i class=\"fa fa-link\"></i></a>xxxx<sup class=\"footnote\" id=\"wiki-fnr1\"><a href=\"#wiki-fn1\">1</a></sup>\n</h2>\n<p class=\"footnote\" id=\"wiki-fn1\"><a href=\"#wiki-fnr1\"><sup>1</sup></a> footnote</p>"
+    output  = "<h2 class=\"editable\" id=\"wiki-foo\"><a class=\"anchor\" id=\"xxxx1\" href=\"#xxxx1\"><i class=\"fa fa-link\"></i></a>xxxx<sup class=\"footnote\" id=\"wiki-fnr1\"><a href=\"#wiki-fn1\">1</a></sup>\n</h2>\n<p class=\"footnote\" id=\"wiki-fn1\"><a href=\"#wiki-fnr1\"><sup>1</sup></a> footnote</p>"
     compare(content, output, :textile)
   end
 
@@ -975,6 +975,18 @@ np.array([[2,2],[1,3]],np.float)
         /id="wiki-Header"/,
         /name="wiki-Header"/
     ]
+  end
+
+  test "adds editable class to headers in the source document" do
+    content = '# Test'
+    output = '<h1 class="editable"><a class="anchor" id="test" href="#test"><i class="fa fa-link"></i></a>Test</h1>'
+    compare(content, output, :markdown)
+  end
+
+  test "does not add editable class to headers in the source document when it contains placeholder" do
+    content = '# Test %SomeFilter%BLA=SomeFilter='
+    output = '<h1><a class="anchor" id="test-somefilter-bla-somefilter" href="#test-somefilter-bla-somefilter"><i class="fa fa-link"></i></a>Test %SomeFilter%BLA=SomeFilter=</h1'
+    compare(content, output, :markdown)
   end
   
   test "toc with h1_title does not include page title" do
@@ -994,7 +1006,7 @@ __TOC__
 # Summary
     MARKDOWN
 
-    output = "<p><strong>TOC</strong></p>\n\n<h1><a class=\"anchor\" id=\"summary\" href=\"#summary\"><i class=\"fa fa-link\"></i></a>Summary</h1>\n\n<h1><a class=\"anchor\" id=\"summary-1\" href=\"#summary-1\"><i class=\"fa fa-link\"></i></a>Summary</h1>"
+    output = "<p><strong>TOC</strong></p>\n\n<h1 class=\"editable\"><a class=\"anchor\" id=\"summary\" href=\"#summary\"><i class=\"fa fa-link\"></i></a>Summary</h1>\n\n<h1 class=\"editable\"><a class=\"anchor\" id=\"summary-1\" href=\"#summary-1\"><i class=\"fa fa-link\"></i></a>Summary</h1>"
     compare(content, output, :markdown)
   end
 
@@ -1007,7 +1019,7 @@ __TOC__
 # Summary !@$#%^&*() stuff
     MARKDOWN
 
-    output = "<p><strong>TOC</strong></p>\n\n<h1><a class=\"anchor\" id=\"summary-stuff\" href=\"#summary-stuff\"><i class=\"fa fa-link\"></i></a>Summary '\"' stuff</h1>\n\n<h1><a class=\"anchor\" id=\"summary-stuff-1\" href=\"#summary-stuff-1\"><i class=\"fa fa-link\"></i></a>Summary !@$#%^&*() stuff</h1>"
+    output = "<p><strong>TOC</strong></p>\n\n<h1 class=\"editable\"><a class=\"anchor\" id=\"summary-stuff\" href=\"#summary-stuff\"><i class=\"fa fa-link\"></i></a>Summary '\"' stuff</h1>\n\n<h1  class=\"editable\"><a class=\"anchor\" id=\"summary-stuff-1\" href=\"#summary-stuff-1\"><i class=\"fa fa-link\"></i></a>Summary !@$#%^&*() stuff</h1>"
     compare(content, output, :markdown)
   end
 
@@ -1024,7 +1036,7 @@ __TOC__
 ### Horse
     MARKDOWN
 
-    output = "<p><strong>TOC</strong></p>\n\n<h1><a class=\"anchor\" id=\"summary\" href=\"#summary\"><i class=\"fa fa-link\"></i></a>Summary</h1>\n\n<h2><a class=\"anchor\" id=\"horse\" href=\"#horse\"><i class=\"fa fa-link\"></i></a>Horse</h2>\n<h1><a class=\"anchor\" id=\"summary-1\" href=\"#summary-1\"><i class=\"fa fa-link\"></i></a>Summary</h1>\n\n<h3><a class=\"anchor\" id=\"horse-1\" href=\"#horse-1\"><i class=\"fa fa-link\"></i></a>Horse</h3>"
+    output = "<p><strong>TOC</strong></p>\n\n<h1 class=\"editable\"><a class=\"anchor\" id=\"summary\" href=\"#summary\"><i class=\"fa fa-link\"></i></a>Summary</h1>\n\n<h2 class=\"editable\"><a class=\"anchor\" id=\"horse\" href=\"#horse\"><i class=\"fa fa-link\"></i></a>Horse</h2>\n<h1 class=\"editable\"><a class=\"anchor\" id=\"summary-1\" href=\"#summary-1\"><i class=\"fa fa-link\"></i></a>Summary</h1>\n\n<h3 class=\"editable\"><a class=\"anchor\" id=\"horse-1\" href=\"#horse-1\"><i class=\"fa fa-link\"></i></a>Horse</h3>"
     compare(content, output, :markdown)
   end
 
@@ -1106,7 +1118,7 @@ def sub_word(mo):
   test 'font awesome class' do
     content = "# hi\n\n[[_TOC_]]"
     # must expect <i class="fa fa-link">
-    output = "<h1><a class=\"anchor\" id=\"hi\" href=\"#hi\"><i class=\"fa fa-link\"></i></a>hi</h1>\n\n<p><div class=\"toc\"><div class=\"toc-title\">Table of Contents</div><ul><li><a href=\"#hi\">hi</a></li></ul></div></p>"
+    output = "<h1 class=\"editable\"><a class=\"anchor\" id=\"hi\" href=\"#hi\"><i class=\"fa fa-link\"></i></a>hi</h1>\n\n<p><div class=\"toc\"><div class=\"toc-title\">Table of Contents</div><ul><li><a href=\"#hi\">hi</a></li></ul></div></p>"
     compare(content, output)
   end
 

--- a/test/test_page.rb
+++ b/test/test_page.rb
@@ -1,7 +1,7 @@
 # ~*~ encoding: utf-8 ~*~
 require File.expand_path(File.join(File.dirname(__FILE__), "helper"))
 
-bilbo_page = "<h1><a class=\"anchor\" id=\"bilbo-baggins\" href=\"#bilbo-baggins\"><i class=\"fa fa-link\"></i></a>Bilbo Baggins</h1>\n\n<p>Bilbo Baggins is the protagonist of The <a class=\"internal present\" href=\"/Hobbit.md\">Hobbit</a> and also makes a few<br />\nappearances in The Lord of the Rings, two of the most well-known of <a class=\"internal absent\" href=\"/J.%20R.%20R.%20Tolkien\">J. R. R. Tolkien</a>'s<br />\nfantasy writings. The story of The Hobbit featuring Bilbo is also<br />\nretold from a different perspective in the Chapter The Quest of Erebor in<br />\nUnfinished Tales.</p>\n\n<p>In Tolkien's narrative conceit, in which all the writings of Middle-earth are<br />\n'really' translations from the fictitious volume of The Red Book of Westmarch,<br />\nBilbo is the author of The Hobbit and translator of The Silmarillion.</p>\n\n<p>From <a href=\"http://en.wikipedia.org/wiki/Bilbo_Baggins\">http://en.wikipedia.org/wiki/Bilbo_Baggins</a>.</p>"
+bilbo_page = "<h1 class=\"editable\"><a class=\"anchor\" id=\"bilbo-baggins\" href=\"#bilbo-baggins\"><i class=\"fa fa-link\"></i></a>Bilbo Baggins</h1>\n\n<p>Bilbo Baggins is the protagonist of The <a class=\"internal present\" href=\"/Hobbit.md\">Hobbit</a> and also makes a few<br />\nappearances in The Lord of the Rings, two of the most well-known of <a class=\"internal absent\" href=\"/J.%20R.%20R.%20Tolkien\">J. R. R. Tolkien</a>'s<br />\nfantasy writings. The story of The Hobbit featuring Bilbo is also<br />\nretold from a different perspective in the Chapter The Quest of Erebor in<br />\nUnfinished Tales.</p>\n\n<p>In Tolkien's narrative conceit, in which all the writings of Middle-earth are<br />\n'really' translations from the fictitious volume of The Red Book of Westmarch,<br />\nBilbo is the author of The Hobbit and translator of The Silmarillion.</p>\n\n<p>From <a href=\"http://en.wikipedia.org/wiki/Bilbo_Baggins\">http://en.wikipedia.org/wiki/Bilbo_Baggins</a>.</p>"
 
 context "Page" do
   setup do
@@ -19,7 +19,7 @@ context "Page" do
     assert_equal Gollum::Page, page.class
     assert page.raw_data =~ /^# Bilbo Baggins\n\nBilbo Baggins/
 
-    expected = bilbo_page #"<h1><a class=\"anchor\" id=\"bilbo-baggins\" href=\"#bilbo-baggins\"><i class=\"fa fa-link\"></i></a>Bilbo Baggins</h1>\n\n<p>Bilbo Baggins is the protagonist of The <a class=\"internal present\" href=\"/Hobbit.md\">Hobbit</a> and also makes a few\nappearances in The Lord of the Rings, two of the most well-known of <a class=\"internal absent\" href=\"/J.%20R.%20R.%20Tolkien\">J. R. R. Tolkien</a>'s fantasy writings. The story of The Hobbit featuring Bilbo is also\nretold from a different perspective in the Chapter The Quest of Erebor in\nUnfinished Tales.</p>\n\n<p>In Tolkien's narrative conceit, in which all the writings of Middle-earth are\n'really' translations from the fictitious volume of The Red Book of Westmarch,\nBilbo is the author of The Hobbit and translator of The Silmarillion.</p>\n\n<p>From <a href=\"http://en.wikipedia.org/wiki/Bilbo_Baggins\">http://en.wikipedia.org/wiki/Bilbo_Baggins</a>.</p>"
+    expected = bilbo_page
     actual   = page.formatted_data
     assert_html_equal expected, actual
 

--- a/test/test_unicode.rb
+++ b/test/test_unicode.rb
@@ -53,7 +53,7 @@ context "Unicode Support" do
 
     assert_equal nfd(expected), nfd(actual)
 
-    expected = nfd(%Q(<h1><a class="anchor" id="#{text.downcase}" href="##{text.downcase}"><i class="fa fa-link"></i></a>#{text}</h1>))
+    expected = nfd(%Q(<h1 class=\"editable\"><a class="anchor" id="#{text.downcase}" href="##{text.downcase}"><i class="fa fa-link"></i></a>#{text}</h1>))
     actual   = nfd(page.formatted_data)
 
     # UTF-8 headers should not be encoded.

--- a/test/test_wiki.rb
+++ b/test/test_wiki.rb
@@ -109,7 +109,7 @@ context "Wiki page previewing" do
   test "preview_page" do
     page = @wiki.preview_page("Test", "# Bilbo", :markdown)
     assert_equal "# Bilbo", page.raw_data
-    assert_html_equal "<h1><a class=\"anchor\" id=\"bilbo\" href=\"#bilbo\"><i class=\"fa fa-link\"></i></a>Bilbo</h1>", page.formatted_data
+    assert_html_equal "<h1 class=\"editable\"><a class=\"anchor\" id=\"bilbo\" href=\"#bilbo\"><i class=\"fa fa-link\"></i></a>Bilbo</h1>", page.formatted_data
     assert_equal "Test.md", page.filename
     assert_equal "Test", page.name
 
@@ -135,7 +135,7 @@ context "Wiki TOC" do
   test "toc_generation" do
     page = @wiki.preview_page("Test", "# Bilbo", :markdown)
     assert_equal "# Bilbo", page.raw_data
-    assert_html_equal "<h1><a class=\"anchor\" id=\"bilbo\" href=\"#bilbo\"><i class=\"fa fa-link\"></i></a>Bilbo</h1>", page.formatted_data
+    assert_html_equal "<h1 class=\"editable\"><a class=\"anchor\" id=\"bilbo\" href=\"#bilbo\"><i class=\"fa fa-link\"></i></a>Bilbo</h1>", page.formatted_data
     assert_html_equal %{<div class="toc"><div class="toc-title">Table of Contents</div><ul><li><a href="#bilbo">Bilbo</a></li></ul></div>}, page.toc_data
   end
 
@@ -153,11 +153,11 @@ context "Wiki TOC" do
     MARKDOWN
 
     formatted = <<-HTML
-<h1><a class="anchor" id="ecthelion" href="#ecthelion"><i class="fa fa-link"></i></a>Ecthelion</h1>
-<h2><a class="anchor" id="denethor" href="#denethor"><i class="fa fa-link"></i></a>Denethor</h2>
-<h3><a class="anchor" id="ecthelion-1" href="#ecthelion-1"><i class="fa fa-link"></i></a>Ecthelion</h3>
-<h3><a class="anchor" id="boromir" href="#boromir"><i class="fa fa-link"></i></a>Boromir</h3>
-<h3><a class="anchor" id="faramir" href="#faramir"><i class="fa fa-link"></i></a>Faramir</h3>
+<h1 class=\"editable\"><a class="anchor" id="ecthelion" href="#ecthelion"><i class="fa fa-link"></i></a>Ecthelion</h1>
+<h2 class=\"editable\"><a class="anchor" id="denethor" href="#denethor"><i class="fa fa-link"></i></a>Denethor</h2>
+<h3 class=\"editable\"><a class="anchor" id="ecthelion-1" href="#ecthelion-1"><i class="fa fa-link"></i></a>Ecthelion</h3>
+<h3 class=\"editable\"><a class="anchor" id="boromir" href="#boromir"><i class="fa fa-link"></i></a>Boromir</h3>
+<h3 class=\"editable\"><a class="anchor" id="faramir" href="#faramir"><i class="fa fa-link"></i></a>Faramir</h3>
     HTML
 
     page_level0 = @wiki.preview_page("Test", "[[_TOC_ | levels=0]] \n\n" + content, :markdown)
@@ -218,7 +218,7 @@ context "Wiki TOC" do
   test "' in link" do
     page = @wiki.preview_page("Test", "# a'b", :markdown)
     assert_equal "# a'b", page.raw_data
-    assert_html_equal "<h1><a class=\"anchor\" id=\"a-b\" href=\"#a-b\"><i class=\"fa fa-link\"></i></a>a'b</h1>", page.formatted_data
+    assert_html_equal "<h1 class=\"editable\"><a class=\"anchor\" id=\"a-b\" href=\"#a-b\"><i class=\"fa fa-link\"></i></a>a'b</h1>", page.formatted_data
     assert_html_equal %{<div class=\"toc\"><div class=\"toc-title\">Table of Contents</div><ul><li><a href=\"#a-b\">a'b</a></li></ul></div>}, page.toc_data
   end
 end


### PR DESCRIPTION
* Mark header elements with the class `editable` in the `process` step of the `Render` filter. Only these headers, as opposed to ones that are potentially added later in the filter chain (e.g. by a Macro), should be presented to the user as editable on a per-section basis.
* API for uniformly generating placeholder/substitution patterns in the filter chain: each `Filter` subclass can call `open_pattern` and `close_pattern`, respectively, to get strings of the form `%SomeFilter%PLACEHOLDERID=SomeFilter='.
* Use this uniformity of substitution patterns to know when to 'bail out' of marking a header as editable (we don't want to mark sections as editable when the section title contains a filter chain placeholder, because we'll have know way of mapping the eventually rendered title to the source document).