### PR TITLE
Feature/fix gem 3

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -107,7 +107,7 @@ end
 
 desc "Build and install"
 task :install => :build do
-  sh "gem install --local --no-ri --no-rdoc pkg/#{name}-#{version}.gem"
+  sh "gem install --local --no-document rdoc,ri pkg/#{name}-#{version}.gem"
 end
 
 #############################################################################

--- a/Rakefile
+++ b/Rakefile
@@ -107,7 +107,7 @@ end
 
 desc "Build and install"
 task :install => :build do
-  sh "gem install --local --no-document rdoc,ri pkg/#{name}-#{version}.gem"
+  sh "gem install --local --no-document pkg/#{name}-#{version}.gem"
 end
 
 #############################################################################


### PR DESCRIPTION
While building gollum in my Docker environment the build started to fail. The Ruby 2.5 images now contains gem version 3. There the already deprecated options `--no-rdoc` and `--no-ri` were removed.