### PR TITLE
Allow to sort pages by created_at and title

### DIFF
--- a/lib/gollum-lib.rb
+++ b/lib/gollum-lib.rb
@@ -33,6 +33,7 @@ require File.expand_path('../gollum-lib/markup', __FILE__)
 require File.expand_path('../gollum-lib/markups', __FILE__)
 require File.expand_path('../gollum-lib/sanitization', __FILE__)
 require File.expand_path('../gollum-lib/filter', __FILE__)
+require File.expand_path('../gollum-lib/sorters/wiki_sorter', __FILE__)
 
 # Set ruby to UTF-8 mode
 # This is required for Ruby 1.8.7 which gollum still supports.

--- a/lib/gollum-lib/git_access.rb
+++ b/lib/gollum-lib/git_access.rb
@@ -172,6 +172,10 @@ module Gollum
       end
     end
 
+    def files_sorted_by_created_at(ref)
+      @repo.files_sorted_by_created_at(ref)
+    end
+
     # Reads the content from the Git db at the given SHA.
     #
     # sha - The String SHA.

--- a/lib/gollum-lib/sorters/wiki_sorter.rb
+++ b/lib/gollum-lib/sorters/wiki_sorter.rb
@@ -1,0 +1,47 @@
+module Gollum
+  module Sorters
+    class WikiSorter
+      SORT_CREATED_AT = "created_at".freeze
+
+      attr_reader :sort, :direction_desc, :limit
+
+      def initialize(sort, direction_desc, limit)
+        @sort = sort
+        @direction_desc = direction_desc
+        @limit = limit
+      end
+
+      def call(sha, access, blobs)
+        if sort == SORT_CREATED_AT
+          by_created_at(sha, access, blobs)
+        else
+          by_title(blobs)
+        end
+      end
+
+      private
+
+      def by_created_at(sha, access, blobs)
+        blobs_by_path = blobs.each_with_object({}) do |entry, hash|
+          hash[entry.path] = entry
+        end
+
+        filenames = access.files_sorted_by_created_at(sha)
+        iterator = direction_desc ? filenames.each : filenames.reverse_each
+
+        iterator.with_object([]) do |filename, blobs|
+          blob = blobs_by_path[filename]
+          next unless blob
+          blobs << blob
+          break blobs if limit && blobs.size == limit
+        end
+      end
+
+      def by_title(blobs)
+        blobs = blobs.reverse if direction_desc
+        blobs = blobs.take(limit) if limit
+        blobs
+      end
+    end
+  end
+end

--- a/test/test_git_access.rb
+++ b/test/test_git_access.rb
@@ -61,4 +61,14 @@ context "GitAccess" do
     assert_not_nil symlink
     assert_equal 0120000, symlink.mode
   end
+
+  test "#files_sorted_by_created_at" do
+    files = [
+      "Mordor/_Footer.md", "My-Precious.md", "Mordor/eye.jpg", "Home.textile",
+      "Mordor/todo.txt", "Mordor/Eye-Of-Sauron.md", "Data.csv", "Bilbo-Baggins.md", "_Footer.md"
+    ]
+
+    sha = '60f12f4254f58801b9ee7db7bca5fa8aeefaa56b'
+    assert_equal files, @access.files_sorted_by_created_at(sha)
+  end
 end

--- a/test/test_wiki.rb
+++ b/test/test_wiki.rb
@@ -52,10 +52,31 @@ context "Wiki" do
   end
 
   test "list pages" do
-    pages = @wiki.pages
-    assert_equal \
-      ['Bilbo-Baggins.md', 'Boromir.md', 'Elrond.md', 'Eye-Of-Sauron.md', 'Hobbit.md', 'Home.textile', 'My-Precious.md', 'RingBearers.md', 'Samwise Gamgee.mediawiki', 'todo.txt'],
-      pages.map(&:filename).sort
+    pages = [
+      'Bilbo-Baggins.md', 'Gondor/Boromir.md', 'Hobbit.md', 'Home.textile', 'Mordor/Eye-Of-Sauron.md',
+      'Mordor/todo.txt', 'My-Precious.md', 'RingBearers.md', 'Rivendell/Elrond.md', 'Samwise Gamgee.mediawiki'
+    ]
+
+    assert_equal pages, @wiki.pages.map(&:path)
+    assert_equal pages.reverse, @wiki.pages(direction_desc: true).map(&:path)
+  end
+
+  test "list pages sorted by date with limit" do
+    first_pages = ["Bilbo Baggins", "Eye Of Sauron", "todo", "Home", "My Precious", "Samwise Gamgee"]
+    last_pages = ["RingBearers", "Hobbit", "Elrond", "Boromir", "Samwise Gamgee", "My Precious"]
+
+    assert_equal first_pages, @wiki.pages(limit: 6, sort: "created_at").map(&:name)
+    assert_equal last_pages, @wiki.pages(limit: 6, sort: "created_at", direction_desc: true).map(&:name)
+  end
+
+  test "list pages sorted by date with limit from a particular reference" do
+    sha = '0ed8cbe0a25235bd867e65193c7d837c66b328ef'
+
+    first_pages = ["Bilbo Baggins", "Eye Of Sauron", "todo", "Home", "My <b>Precious"]
+    last_pages = ["My <b>Precious", "Home", "todo", "Eye Of Sauron", "Bilbo Baggins"]
+
+    assert_equal first_pages, @wiki.pages(sha, limit: 6, sort: "created_at").map(&:name)
+    assert_equal last_pages, @wiki.pages(sha, limit: 6, sort: "created_at", direction_desc: true).map(&:name)
   end
 
   test "list files" do


### PR DESCRIPTION
Hello,

I would like to propose the changes for sorting pages by created-at and title. It requires `files_sorted_by_created_at` to be implemented in adapters (I have implemented in the rugged one https://github.com/gollum/rugged_adapter/pull/32).

Please, let me know what do you think about this functionality and the solutions (if you have better ideas for the solution, I am willing to discuss and work on it)