### PR TITLE
Show `_Template` page at `Overview`

### DIFF
--- a/lib/gollum-lib/page.rb
+++ b/lib/gollum-lib/page.rb
@@ -25,14 +25,14 @@ module Gollum
     end
 
     # Checks if a filename has a valid extension understood by GitHub::Markup.
-    # Also, checks if the filename has no "_" in the front (such as
-    # _Footer.md).
+    # Also, checks if the filename is subpages (such as _Footer.md).
     #
     # filename - String filename, like "Home.md".
     #
     # Returns true or false.
     def self.valid_page_name?(filename)
-      !(filename =~ /^_/) && self.valid_extension?(filename)
+      subpage_names = SUBPAGENAMES.map(&:capitalize).join("|")
+      filename =~ /^_(#{subpage_names})/ ? false : self.valid_extension?(filename)
     end
 
     # Public: The format of a given filename.


### PR DESCRIPTION
Can't get to the `_Template` page because there is no link now.

![Screen Shot 2019-03-20 at 23 14 49](https://user-images.githubusercontent.com/122881/54691250-3e91ca00-4b66-11e9-9b4a-cae221180980.png)

The only way to edit the `_Template` page is to enter the URL
directly.

Hide only subpages(_Header, _Footer, _Sidebar) in `Overview`.

## This PR

![Screen Shot 2019-03-20 at 23 15 12](https://user-images.githubusercontent.com/122881/54691285-51a49a00-4b66-11e9-841b-12ea211858ec.png)

Can show link for `_Template` pages in `Overview`.
Can view and edit `_Template` without having to enter the URL directly
by this patch.