### PR TITLE
Implement Wiki#write_file

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,10 +182,10 @@ commit = { :message => 'commit message',
 ```
 
 Write a new version of a page (the file will be created if it does not already
-exist) and commit the change. The file will be written at the repo root.
+exist) and commit the change. The file will be written at the repo root if no subdirectory is specified.
 
 ```ruby
-wiki.write_page('Page Name', :markdown, 'Page contents', commit)
+wiki.write_page('Subdirectory/Page Name', :markdown, 'Page contents', commit)
 ```
 
 Update an existing page. If the format is different than the page's current

--- a/lib/gollum-lib.rb
+++ b/lib/gollum-lib.rb
@@ -41,19 +41,18 @@ module Gollum
   class Error < StandardError; end
 
   class DuplicatePageError < Error
-    attr_accessor :dir
     attr_accessor :existing_path
     attr_accessor :attempted_path
 
-    def initialize(dir, existing, attempted, message = nil)
-      @dir            = dir
+    def initialize(existing, attempted, message = nil)
       @existing_path  = existing
       @attempted_path = attempted
-      super(message || "Cannot write #{@dir}/#{@attempted_path}, found #{@dir}/#{@existing_path}.")
+      super(message || "Cannot write #{@attempted_path}, found #{@existing_path}.")
     end
   end
 
   class InvalidGitRepositoryError < StandardError; end
   class NoSuchPathError < StandardError; end
+  class IllegalDirectoryPath < StandardError; end
 
 end

--- a/lib/gollum-lib.rb
+++ b/lib/gollum-lib.rb
@@ -41,13 +41,11 @@ module Gollum
   class Error < StandardError; end
 
   class DuplicatePageError < Error
-    attr_accessor :existing_path
     attr_accessor :attempted_path
 
-    def initialize(existing, attempted, message = nil)
-      @existing_path  = existing
+    def initialize(attempted, message = nil)
       @attempted_path = attempted
-      super(message || "Cannot write #{@attempted_path}, found #{@existing_path}.")
+      super(message || "Cannot write #{@attempted_path}: path already exists.")
     end
   end
 

--- a/lib/gollum-lib/committer.rb
+++ b/lib/gollum-lib/committer.rb
@@ -70,35 +70,21 @@ module Gollum
       end
     end
 
-    # Adds a page to the given Index.
+    # Adds a path to the Index.
     #
-    # dir    - The String subdirectory of the Gollum::Page without any
-    #          prefix or suffix slashes (e.g. "foo/bar").
-    # name   - The String Gollum::Page filename_stripped.
-    # format - The Symbol Gollum::Page format.
+    # path   - The String path to be added
     # data   - The String wiki data to store in the tree map.
     #
     # Raises Gollum::DuplicatePageError if a matching filename already exists.
     # This way, pages are not inadvertently overwritten.
     #
     # Returns nothing (modifies the Index in place).
-    def add_to_index(dir, name, format, data, options = {})
-      path = @wiki.page_file_name(name, format)
-
-      dir  = '/' if dir.strip.empty?
-
-      fullpath = ::File.join(*[dir, path])
-      fullpath = fullpath[1..-1] if fullpath =~ /^\//
-
+    def add_to_index(path, data, options = {})
       if index.current_tree && (tree = index.current_tree / (@wiki.page_file_dir || '/'))
-        tree = tree / dir unless tree.nil?
-      end
-
-      if tree
         downpath = path.downcase.sub(/\.\w+$/, '')
 
         tree.blobs.each do |blob|
-          next if page_path_scheduled_for_deletion?(index.tree, fullpath)
+          next if page_path_scheduled_for_deletion?(index.tree, path)
 
           existing_file     = blob.name.downcase.sub(/\.\w+$/, '')
           existing_file_ext = ::File.extname(blob.name).sub(/^\./, '')
@@ -106,14 +92,14 @@ module Gollum
           new_file_ext = ::File.extname(path).sub(/^\./, '')
 
           if downpath == existing_file && (new_file_ext == existing_file_ext)
-            raise DuplicatePageError.new(dir, blob.name, path)
+            raise DuplicatePageError.new(path, blob.name)
           end
         end
       end
 
       # TODO Remove once grit is deprecated
       if Gollum::GIT_ADAPTER == 'grit'
-        fullpath = fullpath.force_encoding('ascii-8bit') if fullpath.respond_to?(:force_encoding)
+        path = path.force_encoding('ascii-8bit') if path.respond_to?(:force_encoding)
       end
 
       unless options[:normalize] == false
@@ -124,30 +110,21 @@ module Gollum
           raise err unless err.message.include?('invalid byte sequence')
         end
       end
-      index.add(fullpath, data)
+      index.add(path, data)
     end
 
     # Update the given file in the repository's working directory if there
     # is a working directory present.
     #
-    # dir    - The String directory in which the file lives.
-    # name   - The String name of the page or the stripped filename
-    #          (should be pre-canonicalized if required).
-    # format - The Symbol format of the page.
+    # path    - The String path to update
     #
     # Returns nothing.
-    def update_working_dir(dir, name, format)
+    def update_working_dir(path)
       unless @wiki.repo.bare
-        if @wiki.page_file_dir && dir !~ /^#{@wiki.page_file_dir}/
-          dir = dir.size.zero? ? @wiki.page_file_dir : ::File.join(@wiki.page_file_dir, dir)
+        if @wiki.page_file_dir && !path.start_with?(@wiki.page_file_dir)
+          # Skip the path if it is not under the wiki's page file dir
+          return nil
         end
-
-        path =
-            if dir == ''
-              @wiki.page_file_name(name, format)
-            else
-              ::File.join(dir, @wiki.page_file_name(name, format))
-            end
         
         if Gollum::GIT_ADAPTER == 'grit'
           path = path.force_encoding('ascii-8bit') if path.respond_to?(:force_encoding)

--- a/lib/gollum-lib/wiki.rb
+++ b/lib/gollum-lib/wiki.rb
@@ -236,7 +236,7 @@ module Gollum
     # Returns the String SHA1 of the newly written version, or the
     # Gollum::Committer instance if this is part of a batch update.
     def write_page(name, format, data, commit = {}, dir = '')
-      write_page_or_file(merge_path_elements(dir, name, format), data, commit)
+     write(merge_path_elements(dir, name, format), data, commit)
     end
 
     # Public: Write a new version of a file to the Gollum repo root.
@@ -258,20 +258,7 @@ module Gollum
     # Returns the String SHA1 of the newly written version, or the
     # Gollum::Committer instance if this is part of a batch update
     def write_file(name, data, commit = {}, dir = '')
-      write_page_or_file(merge_path_elements(dir, name, nil), data, commit)
-    end
-
-    def write_page_or_file(path, data, commit)
-      multi_commit = !!commit[:committer]
-      committer    = multi_commit ? commit[:committer] : Committer.new(self, commit)
-      committer.add_to_index(path, data)
-
-      committer.after_commit do |index, _sha|
-        @access.refresh
-        index.update_working_dir(path)
-      end
-
-      multi_commit ? committer : committer.commit
+      write(merge_path_elements(dir, name, nil), data, commit)
     end
 
     # Public: Rename an existing page without altering content.
@@ -822,6 +809,19 @@ module Gollum
       result = ::File.join([@page_file_dir, '/', dir, self.page_file_name(name, format)].compact)
       raise Gollum::IllegalDirectoryPath if @page_file_dir && !Pathname.new(result).cleanpath.to_s.start_with?(@page_file_dir)
       result[0] == '/' ? result[1..-1] : result
+    end
+
+    def write(path, data, commit = {})
+      multi_commit = !!commit[:committer]
+      committer    = multi_commit ? commit[:committer] : Committer.new(self, commit)
+      committer.add_to_index(path, data)
+
+      committer.after_commit do |index, _sha|
+        @access.refresh
+        index.update_working_dir(path)
+      end
+
+      multi_commit ? committer : committer.commit
     end
 
   end

--- a/lib/gollum-lib/wiki.rb
+++ b/lib/gollum-lib/wiki.rb
@@ -218,7 +218,7 @@ module Gollum
 
     # Public: Write a new version of a page to the Gollum repo root.
     #
-    # name   - The String name of the page.
+    # path   - The String path where the page will be written.
     # format - The Symbol format of the page.
     # data   - The new String contents of the page.
     # commit - The commit Hash details:
@@ -231,8 +231,6 @@ module Gollum
     #          :committer - Optional Gollum::Committer instance.  If provided,
     #                       assume that this operation is part of batch of
     #                       updates and the commit happens later.
-    # dir    - The String subdirectory of the Gollum::Page without any
-    #          prefix or suffix slashes (e.g. "foo/bar").
     # Returns the String SHA1 of the newly written version, or the
     # Gollum::Committer instance if this is part of a batch update.
     def write_page(name, format, data, commit = {})
@@ -241,7 +239,7 @@ module Gollum
 
     # Public: Write a new version of a file to the Gollum repo root.
     #
-    # name   - The String name of the file.
+    # path   - The String path where the file will be written.
     # data   - The new String contents of the page.
     # commit - The commit Hash details:
     #          :message   - The String commit message.
@@ -253,8 +251,6 @@ module Gollum
     #          :committer - Optional Gollum::Committer instance.  If provided,
     #                       assume that this operation is part of batch of
     #                       updates and the commit happens later.
-    # dir    - The String subdirectory of the Gollum::File without any
-    #          prefix or suffix slashes (e.g. "foo/bar").
     # Returns the String SHA1 of the newly written version, or the
     # Gollum::Committer instance if this is part of a batch update
     def write_file(name, data, commit = {})

--- a/lib/gollum-lib/wiki.rb
+++ b/lib/gollum-lib/wiki.rb
@@ -235,8 +235,8 @@ module Gollum
     #          prefix or suffix slashes (e.g. "foo/bar").
     # Returns the String SHA1 of the newly written version, or the
     # Gollum::Committer instance if this is part of a batch update.
-    def write_page(name, format, data, commit = {}, dir = '')
-     write(merge_path_elements(dir, name, format), data, commit)
+    def write_page(name, format, data, commit = {})
+     write(merge_path_elements(nil, name, format), data, commit)
     end
 
     # Public: Write a new version of a file to the Gollum repo root.
@@ -257,8 +257,8 @@ module Gollum
     #          prefix or suffix slashes (e.g. "foo/bar").
     # Returns the String SHA1 of the newly written version, or the
     # Gollum::Committer instance if this is part of a batch update
-    def write_file(name, data, commit = {}, dir = '')
-      write(merge_path_elements(dir, name, nil), data, commit)
+    def write_file(name, data, commit = {})
+      write(merge_path_elements(nil, name, nil), data, commit)
     end
 
     # Public: Rename an existing page without altering content.

--- a/test/test_committer.rb
+++ b/test/test_committer.rb
@@ -125,6 +125,7 @@ context "Wiki" do
     Gollum::Git::Index.any_instance.stubs(:commit).returns(true)
 
     page = @wiki.page(name)
+
     @wiki.repo.git.expects(:checkout).at_least(1).with("#{page_file_dir}/#{name}.md", "HEAD")
     @wiki.update_page(page, page.name, format, "# Elrond", commit_details())
   end

--- a/test/test_committer.rb
+++ b/test/test_committer.rb
@@ -112,7 +112,7 @@ context "Wiki" do
     Gollum::Git::Index.any_instance.stubs(:commit).returns(true)
 
     @wiki.repo.git.expects(:checkout).with("#{page_file_dir}#{dir}/#{name}.md", "HEAD")
-    @wiki.write_page(name, format, "foo bar baz", commit_details, dir)
+    @wiki.write_page(File.join(dir, name), format, "foo bar baz", commit_details)
   end
 
   test "update working directory with page file directory and subdirectory for an existing page" do

--- a/test/test_file.rb
+++ b/test/test_file.rb
@@ -68,4 +68,12 @@ context "File with checkout" do
 
     assert_match(/^FirstName,LastName\n/, file.raw_data)
   end
+
+  test "create new file" do
+    file = @wiki.file('bla/NewFile.myblob')
+    assert_nil file
+    @wiki.write_file('NewFile.myblob', 'MY NEW FILE', {}, 'bla')
+    file = @wiki.file('bla/NewFile.myblob')
+    assert_equal file.raw_data, 'MY NEW FILE'
+  end
 end

--- a/test/test_file.rb
+++ b/test/test_file.rb
@@ -72,7 +72,7 @@ context "File with checkout" do
   test "create new file" do
     file = @wiki.file('bla/NewFile.myblob')
     assert_nil file
-    @wiki.write_file('NewFile.myblob', 'MY NEW FILE', {}, 'bla')
+    @wiki.write_file('/bla/NewFile.myblob', 'MY NEW FILE', {})
     file = @wiki.file('bla/NewFile.myblob')
     assert_equal file.raw_data, 'MY NEW FILE'
   end

--- a/test/test_wiki.rb
+++ b/test/test_wiki.rb
@@ -278,6 +278,9 @@ context "Wiki page writing" do
     assert_equal cd2[:email], first_commit.author.email
     assert @wiki.page("Bilbo")
     assert @wiki.page("Gollum")
+
+    @wiki.write_page("//Saruman", :markdown, "# Saruman", cd2)
+    assert @wiki.page("Saruman")
   end
 
   test "write page is not allowed to overwrite file" do

--- a/test/test_wiki.rb
+++ b/test/test_wiki.rb
@@ -528,7 +528,7 @@ context "Wiki sync with working directory" do
   end
 
   test "write a page in subdirectory" do
-    @wiki.write_page("New Page", :markdown, "Hi", commit_details, "Subdirectory")
+    @wiki.write_page("Subdirectory/New Page", :markdown, "Hi", commit_details)
     assert_equal "Hi", File.read(File.join(@path, "Subdirectory", "New Page.md"))
   end
 
@@ -652,7 +652,7 @@ context "page_file_dir option" do
 
   test "can't write files in root" do
     assert_raises Gollum::IllegalDirectoryPath do
-      @wiki.write_page("Malicious", :markdown, "Hi", {}, "../")
+      @wiki.write_page("../Malicious", :markdown, "Hi", {})
     end
   end
 

--- a/test/test_wiki.rb
+++ b/test/test_wiki.rb
@@ -647,6 +647,12 @@ context "page_file_dir option" do
     assert_equal "docs/foo", results[0][:name]
   end
 
+  test "can't write files in root" do
+    assert_raises Gollum::IllegalDirectoryPath do
+      @wiki.write_page("Malicious", :markdown, "Hi", {}, "../")
+    end
+  end
+
   teardown do
     FileUtils.rm_r(@path)
   end

--- a/test/test_wiki.rb
+++ b/test/test_wiki.rb
@@ -283,10 +283,13 @@ context "Wiki page writing" do
   test "write page is not allowed to overwrite file" do
     @wiki.write_page("Abc-Def", :markdown, "# Gollum", commit_details)
     assert_raises Gollum::DuplicatePageError do
-      @wiki.write_page("aBC-dEF", :markdown, "# Gollum", commit_details)
+      @wiki.write_page("Abc-Def", :markdown, "# Gollum", commit_details)
     end
     assert_nothing_raised Gollum::DuplicatePageError do
       @wiki.write_page("Abc-Def", :textile, "# Gollum", commit_details)
+    end
+    assert_nothing_raised Gollum::DuplicatePageError do
+      @wiki.write_page("abc-def", :markdown, "# Gollum", commit_details)
     end
   end
 


### PR DESCRIPTION
Adds `Wiki#write_file` to the API.

Until now, the API only allowed for adding *pages* to the wiki, and not *files*. That is why the logic for uploading files in gollum is [directly doing commits from the frontend](https://github.com/gollum/gollum/blob/master/lib/gollum/app.rb#L210-L218). Ouch.

This PR is a prerequisite for merging https://github.com/gollum/gollum/pull/1369 as it ensures that the `:page_file_dir` option is respected when writing a new file to the wiki.

While refactoring the `Committer` class for this PR, I also noticed that we were still throwing `DuplicatePageError`s when the updated path case-**in**sensitively matched a file in the wiki. Since we have case sensitive filepaths in `5.x`, that's a bug. I added a test to guard against that. This also makes the `Committer#add_to_index` method much cleaner and more efficient.