### PR TITLE
Fix Page#url_title: no file extension

### DIFF
--- a/lib/gollum-lib/page.rb
+++ b/lib/gollum-lib/page.rb
@@ -116,7 +116,7 @@ module Gollum
     #
     # Returns the String title
     def url_path_title
-      metadata_title || ::File.join(::File.dirname(url_title), name)
+      metadata_title || name
     end
 
     # Public: Metadata title

--- a/lib/gollum-lib/page.rb
+++ b/lib/gollum-lib/page.rb
@@ -116,7 +116,7 @@ module Gollum
     #
     # Returns the String title
     def url_path_title
-      metadata_title || url_path
+      metadata_title || ::File.join(::File.dirname(self.path), self.name)
     end
 
     # Public: Metadata title

--- a/lib/gollum-lib/page.rb
+++ b/lib/gollum-lib/page.rb
@@ -116,7 +116,7 @@ module Gollum
     #
     # Returns the String title
     def url_path_title
-      metadata_title || ::File.join(::File.dirname(self.path), self.name)
+      metadata_title || ::File.join(::File.dirname(url_title), name)
     end
 
     # Public: Metadata title


### PR DESCRIPTION
Just noticed that removing the `construct_path` private method from the `Page` class resulted in the `url_path_title` being different from what gollum expects: it was expecting the title without the file extension. This PR removes the file extension from the url_path_title is a straightforward manner, without the need for something like `construct_path`.

Question: is the desired behavior for the title to include the directory path? That was the point of `construct_path`, but won't that result in super long titles? I can remember there being an issue about that, but can't figure out what we decided now.