### PR TITLE
Fix deletion with page_file_dir

### DIFF
--- a/lib/gollum-lib/wiki.rb
+++ b/lib/gollum-lib/wiki.rb
@@ -358,21 +358,7 @@ module Gollum
     # Returns the String SHA1 of the newly written version, or the
     # Gollum::Committer instance if this is part of a batch update.
     def delete_page(page, commit)
-
-      multi_commit = !!commit[:committer]
-      committer    = multi_commit ? commit[:committer] : Committer.new(self, commit)
-
-      committer.delete(page.path)
-
-      committer.after_commit do |index, _sha|
-        dir = ::File.dirname(page.path)
-        dir = '' if dir == '.'
-
-        @access.refresh
-        index.update_working_dir(merge_path_elements(dir, page.filename_stripped, page.format))
-      end
-
-      multi_commit ? committer : committer.commit
+      delete_file(page_file_dir ? page.url_path : page.path, commit)
     end
 
     # Public: Delete a file.
@@ -392,21 +378,16 @@ module Gollum
     # Returns the String SHA1 of the newly written version, or the
     # Gollum::Committer instance if this is part of a batch update.
     def delete_file(path, commit)
-      dir      = ::File.dirname(path)
-      ext      = ::File.extname(path)
-      format   = ext.split('.').last || 'txt'
-      filename = ::File.basename(path, ext)
-
+      fullpath     = ::File.join([page_file_dir, path].compact)
       multi_commit = !!commit[:committer]
       committer    = multi_commit ? commit[:committer] : Committer.new(self, commit)
 
-      committer.delete(path)
+      committer.delete(fullpath)
 
       committer.after_commit do |index, _sha|
         dir = '' if dir == '.'
-
         @access.refresh
-        index.update_working_dir(merge_path_elements(dir, filename, format))
+        index.update_working_dir(fullpath)
       end
 
       multi_commit ? committer : committer.commit

--- a/lib/gollum-lib/wiki.rb
+++ b/lib/gollum-lib/wiki.rb
@@ -358,7 +358,7 @@ module Gollum
     # Returns the String SHA1 of the newly written version, or the
     # Gollum::Committer instance if this is part of a batch update.
     def delete_page(page, commit)
-      delete_file(page_file_dir ? page.url_path : page.path, commit)
+      delete_file(page.url_path, commit)
     end
 
     # Public: Delete a file.

--- a/test/test_wiki.rb
+++ b/test/test_wiki.rb
@@ -651,6 +651,14 @@ context "page_file_dir option" do
     @wiki.update_page(page, page.name, page.format, 'new contents', commit_details)
   end
 
+  test 'delete a page' do
+    @wiki.write_page("New Page", :markdown, "Hi", commit_details)
+    result = @wiki.page("New Page")
+    assert_not_nil result
+    @wiki.delete_page(result, commit_details)
+    assert_nil @wiki.page("New Page")
+  end
+
   test "a file in page file dir should be found" do
     assert @wiki.page("foo")
   end


### PR DESCRIPTION
Turns out deleting files/pages was not being tested with the page_file_dir option, and was broken. This PR addresses the issue, adds a test, and refactors the deletion methods.