### PR TITLE
Determine markup format from format name rather than filename

### DIFF
--- a/lib/gollum-lib/filter/render.rb
+++ b/lib/gollum-lib/filter/render.rb
@@ -6,7 +6,7 @@ class Gollum::Filter::Render < Gollum::Filter
       working_dir = Pathname.new(@markup.wiki.path).join(@markup.dir)
       working_dir = working_dir.exist? ? working_dir.to_s : '.'
       Dir.chdir(working_dir) do
-        data = GitHub::Markup.render_s(Gollum::Markup.formats[@markup.format][:name].downcase.to_sym, data)
+        data = GitHub::Markup.render_s(@markup.format, data)
       end
       if data.nil?
         raise "There was an error converting #{@markup.name} to HTML."

--- a/lib/gollum-lib/filter/render.rb
+++ b/lib/gollum-lib/filter/render.rb
@@ -6,7 +6,7 @@ class Gollum::Filter::Render < Gollum::Filter
       working_dir = Pathname.new(@markup.wiki.path).join(@markup.dir)
       working_dir = working_dir.exist? ? working_dir.to_s : '.'
       Dir.chdir(working_dir) do
-        data = GitHub::Markup.render(@markup.name, data)
+        data = GitHub::Markup.render_s(Gollum::Markup.formats[@markup.format][:name].downcase.to_sym, data)
       end
       if data.nil?
         raise "There was an error converting #{@markup.name} to HTML."

--- a/lib/gollum-lib/markups.rb
+++ b/lib/gollum-lib/markups.rb
@@ -76,7 +76,7 @@ module Gollum
     register(:creole, "Creole",
              :enabled => MarkupRegisterUtils::gem_exists?("creole"),
              :reverse_links => true)
-    register(:rest, "reStructuredText",
+    register(:rst, "reStructuredText",
              :enabled => MarkupRegisterUtils::executable_exists?("python2"),
              :extensions => ['rest', 'rst'])
     register(:asciidoc, "AsciiDoc",

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -91,6 +91,22 @@ context "Markup" do
     end
   end
 
+  test 'github-markup knows about gollum markups' do
+    markups_with_render_filter = Gollum::Markup.formats.select do |k, v|
+      case v[:skip_filters]
+      when Array
+        !v[:skip_filters].include?(:Render)
+      when Proc
+        !v[:skip_filters].call(:Render)
+      else
+        true
+      end
+    end
+    markups_with_render_filter.each do |name, info|
+      assert ::GitHub::Markup.markups.key?(name), "GitHub::Markup does not know about format #{name}"
+    end
+  end
+
   #########################################################################
   #
   # Links


### PR DESCRIPTION
Well, I didn't get to it as soon as I would have liked, but I've redone https://github.com/gollum/gollum-lib/pull/285. To recap, this change makes Gollum use the markup defined in `Gollum::Markup.formats` to render text rather that the source's file extension. This allows users to change which extensions are used for which markups, as I do in [this blog post](https://davidyat.es/2017/09/01/vimwiki-plus-gollum/).