### PR TITLE
Make code filter conform to GitHub

### DIFF
--- a/lib/gollum-lib/filter/code.rb
+++ b/lib/gollum-lib/filter/code.rb
@@ -20,25 +20,21 @@ class Gollum::Filter::Code < Gollum::Filter
         "#{Regexp.last_match[3]}#{cache_codeblock(Regexp.last_match[4], Regexp.last_match[5])}"
       end
     when :markdown
-      data.gsub!(/^([ \t]*)(~~~+) ?([^\r\n]+)?\r?\n(.+?)\r?\n\1(~~~+)[ \t\r]*$/m) do
+      data.gsub!(/^([ ]{0,3})(~~~+) ?([^\r\n]+)?\r?\n(.+?)\r?\n[ ]{0,3}(~~~+)[ \t\r]*$/m) do
         m_indent = Regexp.last_match[1]
         m_start  = Regexp.last_match[2] # ~~~
         m_lang   = Regexp.last_match[3]
         m_code   = Regexp.last_match[4]
         m_end    = Regexp.last_match[5] # ~~~
-        # start and finish tilde fence must be the same length
-        next '' if m_start.length != m_end.length
-        lang = m_lang ? m_lang.strip : nil
-        if lang
-          lang = lang.match(/\.([^}\s]+)/)
-          lang = lang[1] unless lang.nil?
-        end
+        # The closing code fence must be at least as long as the opening fence
+        next '' if m_end.length < m_start.length
+        lang = m_lang ? m_lang.strip.split.first : nil
         "#{m_indent}#{cache_codeblock(lang, m_code, m_indent)}"
       end  
     end
     
 
-    data.gsub!(/^([ \t]*)``` ?([^\r\n]+)?\r?\n(.+?)\r?\n\1```[ \t]*\r?$/m) do
+    data.gsub!(/^([ ]{0,3})``` ?([^\r\n]+)?\r?\n(.+?)\r?\n[ ]{0,3}```[ \t]*\r?$/m) do
       "#{Regexp.last_match[1]}#{cache_codeblock(Regexp.last_match[2].to_s.strip, Regexp.last_match[3], Regexp.last_match[1])}" # print the SHA1 ID with the proper indentation
     end
     data

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -338,13 +338,25 @@ org
     page = 'test_rgx'
     @wiki.write_page(page, :markdown,
         (<<-'DATA'
-          ```
-          rot13='tr '\''A-Za-z'\'' '\''N-ZA-Mn-za-m'\'
-          ```
+  ```
+  rot13='tr '\''A-Za-z'\'' '\''N-ZA-Mn-za-m'\'
+  ```
         DATA
         ), commit_details)
     output   = @wiki.page(page).formatted_data
-    expected = %Q{<pre><code>      <pre class=\"highlight\"><code>rot13='tr '\\''A-Za-z'\\'' '\\''N-ZA-Mn-za-m'\\'</code></pre>\n</code></pre>}
+    expected = %Q{<pre class=\"highlight\"><code>rot13='tr '\\''A-Za-z'\\'' '\\''N-ZA-Mn-za-m'\\'</code></pre>}
+    assert_html_equal expected, output
+  end
+
+  test "backtick code blocks must have no more than three space indents" do
+    page = 'test_rgx'
+    @wiki.write_page(page, :markdown,
+                     %Q(    ```ruby
+'hi'
+```
+      ), commit_details)
+    output   = @wiki.page(page).formatted_data
+    expected = %Q{<pre><code>```ruby 'hi' ```\n</code></pre>}
     assert_html_equal expected, output
   end
 
@@ -365,7 +377,7 @@ org
   test "tilde code blocks #537" do
     page = 'test_rgx'
     @wiki.write_page(page, :markdown,
-                     %Q(~~~ {.ruby}
+                     %Q(~~~ruby
 'hi'
 ~~~
       ), commit_details)
@@ -374,11 +386,34 @@ org
     assert_html_equal expected, output
   end
 
-  # Issue #537
-  test "tilde code blocks with more than one class" do
+  test "tilde code blocks must have no more than three space indents" do
     page = 'test_rgx'
     @wiki.write_page(page, :markdown,
-                     %Q(~~~ {#hi .ruby .sauce}
+                     %Q(    ~~~ruby
+'hi'
+~~~
+      ), commit_details)
+    output   = @wiki.page(page).formatted_data
+    expected = %Q{<pre><code>~~~ruby 'hi' ~~~\n</code></pre>}
+    assert_html_equal expected, output
+  end
+
+  test "tilde code blocks must have longer end tag than opening tag" do
+    page = 'test_rgx'
+    @wiki.write_page(page, :markdown,
+                     %Q(~~~~ruby
+'hi'
+~~~
+      ), commit_details)
+    output   = @wiki.page(page).formatted_data
+    expected = %Q{\n}
+    assert_html_equal expected, output
+  end
+
+  test "tilde code blocks with more than one word in info string" do
+    page = 'test_rgx'
+    @wiki.write_page(page, :markdown,
+                     %Q(~~~ ruby bla
 'hi'
 ~~~
       ), commit_details)
@@ -392,7 +427,7 @@ org
   test "tilde code blocks with lots of tildes" do
     page = 'test_rgx'
     @wiki.write_page(page, :markdown,
-                     %Q(~~~~~~ {#hi .ruby .sauce}
+                     %Q(~~~~~~ruby
 ~~
 'hi'~
 ~~~~~~


### PR DESCRIPTION
According to the [GFM spec](https://github.github.com/gfm/#fenced-code-blocks), fenced code blocks can't have more than three spaces indent, and opening and closing tags don't have to have the same amount of indent.

Closing tags must also have at least as many characters as opening tags. However, gollum only supports exactly three backticks for fenced codeblocks on all pages. This PR implements the minimum length for end tags for tilde-style `~~~` fenced code blocks on markdown, however.

Also solved a bug that was causing the info-string (codeblock language) not to be correctly parsed for tilde fenced blocks: `~~~ruby` was illegal, `~~~.ruby` expected, but this is not correct according to the current GFM spec.

Question:

> However, gollum only supports exactly three backticks for fenced codeblocks on all pages.

Does that strike us as sane behavior, or do we want fenced codeblocks that can use any number of backticks (higher than three, and at least as long end tag as star tag)?