### PR TITLE
Add Note() and Warn() flash macros. Add Octicon() macro. Improve Macro error rendering.

### DIFF
--- a/gemspec.rb
+++ b/gemspec.rb
@@ -32,6 +32,7 @@ def specification(version, default_adapter, platform = nil)
     s.add_dependency 'sanitize', '~> 2.1.1', '>= 2.1.1'
     s.add_dependency 'github-markup', '~> 3.0'
     s.add_dependency 'gemojione', '~> 3.2'
+    s.add_dependency 'octicons', '~> 8.5'
     s.add_dependency 'twitter-text', '1.14.7'
 
     s.add_development_dependency 'org-ruby', '~> 0.9.9'

--- a/lib/gollum-lib/filter/macro.rb
+++ b/lib/gollum-lib/filter/macro.rb
@@ -1,4 +1,5 @@
 # ~*~ encoding: utf-8 ~*~
+require 'octicons'
 
 # Replace specified tokens with dynamically generated content.
 class Gollum::Filter::Macro < Gollum::Filter
@@ -47,7 +48,9 @@ class Gollum::Filter::Macro < Gollum::Filter
         begin
           Gollum::Macro.instance(macro, @markup.wiki, @markup.page).render(*args)
         rescue StandardError => e
-          "!!!Macro Error: #{e.message}!!!"
+          icon = Octicons::Octicon.new('zap', {width: 24, height: 24})
+          icon.options[:class] << ' mr-2'
+          "<div class='flash flash-error'>#{icon.to_svg}!!!Macro Error for #{macro}: #{e.message}!!!</div>"
         end
       end
     end

--- a/lib/gollum-lib/filter/macro.rb
+++ b/lib/gollum-lib/filter/macro.rb
@@ -50,7 +50,7 @@ class Gollum::Filter::Macro < Gollum::Filter
         rescue StandardError => e
           icon = Octicons::Octicon.new('zap', {width: 24, height: 24})
           icon.options[:class] << ' mr-2'
-          "<div class='flash flash-error'>#{icon.to_svg}!!!Macro Error for #{macro}: #{e.message}!!!</div>"
+          "<div class='flash flash-error'>#{icon.to_svg}Macro Error for #{macro}: #{e.message}</div>"
         end
       end
     end

--- a/lib/gollum-lib/macro/note.rb
+++ b/lib/gollum-lib/macro/note.rb
@@ -1,10 +1,18 @@
 module Gollum
   class Macro
     class Note < Gollum::Macro
-      def render(notice)
-        icon = Octicons::Octicon.new('info', {width: 24, height: 24})
-        icon.options[:class] << ' mr-2'
-        "<div class='flash'>#{icon.to_svg}#{notice}</div>"
+      def render(notice, octicon = 'info')
+        icon = ""
+        unless octicon.empty?
+          begin
+            icon = Octicons::Octicon.new(octicon, {width: 24, height: 24})
+          rescue RuntimeError
+            icon = Octicons::Octicon.new('info', {width: 24, height: 24})
+          end
+          icon.options[:class] << ' mr-2'
+          icon = icon.to_svg
+        end
+        "<div class='flash'>#{icon}#{notice}</div>"
       end
     end
   end

--- a/lib/gollum-lib/macro/note.rb
+++ b/lib/gollum-lib/macro/note.rb
@@ -1,0 +1,11 @@
+module Gollum
+  class Macro
+    class Note < Gollum::Macro
+      def render(notice)
+        icon = Octicons::Octicon.new('info', {width: 24, height: 24})
+        icon.options[:class] << ' mr-2'
+        "<div class='flash'>#{icon.to_svg}#{notice}</div>"
+      end
+    end
+  end
+end

--- a/lib/gollum-lib/macro/octicon.rb
+++ b/lib/gollum-lib/macro/octicon.rb
@@ -1,0 +1,12 @@
+module Gollum
+  class Macro
+    class Octicon < Gollum::Macro
+      def render(symbol, height = nil, width = nil)
+        parameters = {}
+        parameters[:height] = height if height
+        parameters[:width]  = width if width
+        "<div>#{Octicons::Octicon.new(symbol, parameters).to_svg}</div>"
+      end
+    end
+  end
+end

--- a/lib/gollum-lib/macro/warn.rb
+++ b/lib/gollum-lib/macro/warn.rb
@@ -1,0 +1,11 @@
+module Gollum
+  class Macro
+    class Warn < Gollum::Macro
+      def render(warning)
+        icon = Octicons::Octicon.new('alert', {width: 24, height: 24})
+        icon.options[:class] << ' mr-2'
+        "<div class='flash flash-warn'>#{icon.to_svg}#{warning}</div>"
+      end
+    end
+  end
+end

--- a/test/test_macros.rb
+++ b/test/test_macros.rb
@@ -164,7 +164,7 @@ context "Macros" do
 
   test "Macro errors are reported in place in a flash-error message box" do
     @wiki.write_page("OcticonMacroPage", :markdown, '<<Octicon("foobar", 64, 64)>>', commit_details)
-    assert_match /<div class=\"flash flash-error\"><svg.*class=\"octicon octicon-zap mr-2\".*!!!Macro Error for Octicon: Couldn't find octicon symbol for "foobar"!!!.*/, @wiki.pages[0].formatted_data
+    assert_match /<div class=\"flash flash-error\"><svg.*class=\"octicon octicon-zap mr-2\".*Macro Error for Octicon: Couldn't find octicon symbol for "foobar".*/, @wiki.pages[0].formatted_data
   end
 
 end

--- a/test/test_macros.rb
+++ b/test/test_macros.rb
@@ -133,17 +133,36 @@ context "Macros" do
     assert_match(/@xyzzy = Foo@/, @wiki.pages[0].formatted_data)
   end
 
-   
-  test "Video macro given a name of a file displays an html5 video tag " do
+  test "Video macro given a name of a file displays an html5 video tag" do
     file = "/Uploads/foo.mp4"
     @wiki.write_page("VideoTagTest", :markdown, "<<Video(#{file})>>", commit_details)
     assert_match /<video (.*) (.*) src="#{file}" (.*)> (.*)<\/video>/, @wiki.pages[0].formatted_data
   end 
 
-  test "Audio macro given a name of a file displays an audio tag " do
+  test "Audio macro given a name of a file displays an audio tag" do
     file = "/Uploads/foo.mp3"
     @wiki.write_page("AudioTagTest", :markdown, "<<Audio(#{file})>>", commit_details)
     assert_match /<audio (.*) (.*) src="#{file}" (.*)> (.*)<\/audio>/, @wiki.pages[0].formatted_data
+  end
+
+  test "Octicon macro given a symbol and dimensions displays octicon" do
+    @wiki.write_page("OcticonMacroPage", :markdown, '<<Octicon("globe", 64, 64)>>', commit_details)
+    assert_match /<div><svg.*class=\"octicon octicon-globe\".*height=\"64\".*width=\"64\".*/, @wiki.pages[0].formatted_data
+  end
+
+  test "Note macro given a string displays a regular flash message box" do
+    @wiki.write_page("NoteMacroPage", :markdown, '<<Note("Did you know Bilbo is a Hobbit?")>>', commit_details)
+    assert_match /<div class=\"flash\"><svg.*class=\"octicon octicon-info mr-2\".*Did you know Bilbo.*/, @wiki.pages[0].formatted_data
+  end
+
+  test "Warn macro given a string displays a flash-warning message box" do
+    @wiki.write_page("WarnMacroPage", :markdown, '<<Warn("Be careful not to mention hobbits in conversation too much.")>>', commit_details)
+    assert_match /<div class=\"flash flash-warn\"><svg.*class=\"octicon octicon-alert mr-2\".*Be careful.*/, @wiki.pages[0].formatted_data
+  end
+
+  test "Macro errors are reported in place in a flash-error message box" do
+    @wiki.write_page("OcticonMacroPage", :markdown, '<<Octicon("foobar", 64, 64)>>', commit_details)
+    assert_match /<div class=\"flash flash-error\"><svg.*class=\"octicon octicon-zap mr-2\".*!!!Macro Error for Octicon: Couldn't find octicon symbol for "foobar"!!!.*/, @wiki.pages[0].formatted_data
   end
 
 end

--- a/test/test_macros.rb
+++ b/test/test_macros.rb
@@ -147,7 +147,9 @@ context "Macros" do
 
   test "Octicon macro given a symbol and dimensions displays octicon" do
     @wiki.write_page("OcticonMacroPage", :markdown, '<<Octicon("globe", 64, 64)>>', commit_details)
-    assert_match /<div><svg.*class=\"octicon octicon-globe\".*height=\"64\".*width=\"64\".*/, @wiki.pages[0].formatted_data
+    assert_match /<div><svg.*class=\"octicon octicon-globe\".*/, @wiki.pages[0].formatted_data
+    assert_match /<div><svg.*height=\"64\"/, @wiki.pages[0].formatted_data
+    assert_match /<div><svg.*width=\"64\"/, @wiki.pages[0].formatted_data
   end
 
   test "Note macro given a string displays a regular flash message box" do


### PR DESCRIPTION
This PR adds two macros for adding notes or warnings to a wiki page. The syntax for these is straightforward, each takes a String (see the example below). In addition, this PR adds a macro for adding any of the [Octicons](https://octicons.github.com/) to a wiki page. This macro takes a String argument for determining which octicon to render, plus two optional arguments for setting the height and width of the image. 

![Screen Shot 2019-09-26 at 20 14 59](https://user-images.githubusercontent.com/571173/65713861-5d839280-e09a-11e9-9490-77ee7d561394.png)

Finally, the PR also enhances the way Macro errors are rendered on a page. The rendered result of the above is as follows.

![Screen Shot 2019-09-26 at 09 58 36](https://user-images.githubusercontent.com/571173/65712041-7427ea80-e096-11e9-9369-d0027105f91d.png)
