### PR TITLE
Prevent exception in RemoteCode

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
 source 'https://rubygems.org'
 
 if RUBY_PLATFORM == 'java'
-  gem 'gollum-rjgit_adapter', :git => 'https://github.com/repotag/gollum-lib_rjgit_adapter' # For development purposes
+  gem 'gollum-rjgit_adapter', :git => 'https://github.com/gollum/rjgit_adapter' # For development purposes
 else
-  gem 'gollum-rugged_adapter', :git => 'https://github.com/dometto/rugged_adapter.git'  # For development purposes
+  gem 'gollum-rugged_adapter', :git => 'https://github.com/gollum/rugged_adapter'  # For development purposes
 end
 
 gemspec :name => 'gollum-lib'

--- a/lib/gollum-lib/filter/remote_code.rb
+++ b/lib/gollum-lib/filter/remote_code.rb
@@ -45,7 +45,8 @@ class Gollum::Filter::RemoteCode < Gollum::Filter
     return "Too many redirects or retries" if cut >= 10
     http         = Net::HTTP.new uri.host, uri.port
     http.use_ssl = true
-    resp         = http.get uri.path, {
+    path         = uri.path.empty? ? '/' : uri.path
+    resp         = http.get path, {
         'Accept'        => 'text/plain',
         'Cache-Control' => 'no-cache',
         'Connection'    => 'keep-alive',


### PR DESCRIPTION
Using
~~~
```ruby:https://foo.com```
~~~

would fail because there was no subpath in the request.