### PR TITLE
Replace Sanitize with Loofah. Resolves #320

### DIFF
--- a/gemspec.rb
+++ b/gemspec.rb
@@ -29,7 +29,7 @@ def specification(version, default_adapter, platform = nil)
     s.add_dependency 'rouge', '~> 3.1'
     s.add_dependency 'nokogiri', '~> 1.8'
     s.add_dependency 'stringex', '~> 2.6'
-    s.add_dependency 'sanitize', '~> 2.1.1', '>= 2.1.1'
+    s.add_dependency 'loofah', '~> 2.3'
     s.add_dependency 'github-markup', '~> 3.0'
     s.add_dependency 'gemojione', '~> 3.2'
     s.add_dependency 'octicons', '~> 8.5'

--- a/lib/gollum-lib.rb
+++ b/lib/gollum-lib.rb
@@ -13,8 +13,8 @@ require "#{Gollum::GIT_ADAPTER.downcase}_adapter"
 # external
 require 'github/markup'
 require 'erb'
-require 'sanitize'
 require 'gemojione'
+require 'loofah'
 
 # internal
 require File.expand_path('../gollum-lib/git_access', __FILE__)

--- a/lib/gollum-lib/filter.rb
+++ b/lib/gollum-lib/filter.rb
@@ -52,6 +52,7 @@ module Gollum
     # Setup the object.  Sets `@markup` to be the instance of Gollum::Markup that
     # is running this filter chain, and sets `@map` to be an empty hash (for use
     # in your extract/process operations).
+
     def initialize(markup)
       @markup = markup
       @map    = {}
@@ -72,6 +73,11 @@ module Gollum
     end
 
     protected
+
+    def sanitize(data)
+      @markup.wiki.sanitizer.clean(data, @markup.historical)
+    end
+
     # Render a (presumably) non-fatal error as HTML
     #
     def html_error(message)

--- a/lib/gollum-lib/filter/render.rb
+++ b/lib/gollum-lib/filter/render.rb
@@ -37,7 +37,7 @@ class Gollum::Filter::Render < Gollum::Filter
         header['class'] = 'editable'
       end
     end
-    doc.to_xml(@markup.to_xml_opts)
+    doc.to_xml(@markup.class.to_xml_opts)
   end
 
 end

--- a/lib/gollum-lib/filter/sanitize.rb
+++ b/lib/gollum-lib/filter/sanitize.rb
@@ -6,13 +6,6 @@ class Gollum::Filter::Sanitize < Gollum::Filter
   end
 
   def process(data)
-    if @markup.sanitize
-      doc = Nokogiri::HTML::DocumentFragment.parse(data)
-      doc = @markup.sanitize.clean_node!(doc)
-
-      doc.to_xml(@markup.to_xml_opts).gsub(/<p><\/p>/, '')
-    else
-      data
-    end
+    sanitize(data)
   end
 end

--- a/lib/gollum-lib/filter/tags.rb
+++ b/lib/gollum-lib/filter/tags.rb
@@ -173,14 +173,8 @@ class Gollum::Filter::Tags < Gollum::Filter
   # Return the String HTML if the tag is a valid external link tag or
   # nil if it is not.
   def process_external_link_tag(url, pretty_name = nil)
-    accepted_protocols = @markup.wiki.sanitization.protocols['a']['href'].dup
-    if accepted_protocols.include?(:relative)
-      accepted_protocols.select!{|protocol| protocol != :relative}
-      regexp = %r{^((#{accepted_protocols.join("|")}):)?(//)}
-    else
-      regexp = %r{^((#{accepted_protocols.join("|")}):)}
-    end
-    if url =~ regexp
+    @accepted_protocols_regex ||= %r{^((#{::Gollum::Sanitization.accepted_protocols.join('|')}):)?(//)} 
+    if url =~ @accepted_protocols_regex
       generate_link(url, pretty_name, nil, :external)
     else
       nil

--- a/lib/gollum-lib/filter/toc.rb
+++ b/lib/gollum-lib/filter/toc.rb
@@ -26,10 +26,10 @@ class Gollum::Filter::TOC < Gollum::Filter
         add_entry_to_toc     header, anchor_name
       end
       if not @toc_doc.nil?
-        toc_str = @toc_doc.to_xml(@markup.to_xml_opts)
+        toc_str = @toc_doc.to_xml(@markup.class.to_xml_opts)
       end
 
-      data  = @doc.to_xml(@markup.to_xml_opts)
+      data  = @doc.to_xml(@markup.class.to_xml_opts)
     end
 
     @markup.toc = toc_str
@@ -51,7 +51,7 @@ class Gollum::Filter::TOC < Gollum::Filter
             e.remove
           end
         end
-        toc_clone.to_xml(@markup.to_xml_opts)
+        toc_clone.to_xml(@markup.class.to_xml_opts)
       end
     end
 

--- a/lib/gollum-lib/filter/yaml.rb
+++ b/lib/gollum-lib/filter/yaml.rb
@@ -10,7 +10,7 @@ class Gollum::Filter::YAML < Gollum::Filter
     data.gsub!(YAML_FRONT_MATTER_REGEXP) do
       @markup.metadata ||= {}
       begin
-        frontmatter = ::YAML.safe_load(@markup.sanitize.clean(Regexp.last_match[1]))
+        frontmatter = ::YAML.safe_load(sanitize(Regexp.last_match[1]))
         @markup.metadata.merge!(frontmatter) if frontmatter.respond_to?(:keys) && frontmatter.respond_to?(:values)
       rescue ::Psych::SyntaxError, ::Psych::DisallowedClass, ::Psych::BadAlias => error
         @markup.metadata['errors'] ||= []

--- a/lib/gollum-lib/page.rb
+++ b/lib/gollum-lib/page.rb
@@ -101,7 +101,7 @@ module Gollum
     #
     # Returns the fully sanitized String title.
     def title
-      Sanitize.clean(name).strip
+      @wiki.sanitizer.clean(name).strip
     end
 
     # Public: Determines if this is a sub-page

--- a/lib/gollum-lib/sanitization.rb
+++ b/lib/gollum-lib/sanitization.rb
@@ -1,378 +1,65 @@
-# ~*~ encoding: utf-8 ~*~
+::Loofah::HTML5::SafeList::ACCEPTABLE_PROTOCOLS.add('apt')
+
 module Gollum
-  # Encapsulate sanitization options.
-  #
-  # This class does not yet support all options of Sanitize library.
-  # See http://github.com/rgrove/sanitize/.
   class Sanitization
 
-    # Default whitelisted elements required for MathML. See https://developer.mozilla.org/en-US/docs/Web/MathML/Element
-    # For some help on generating MATHML_ELEMENTS and MATHML_ATTRS, see https://gist.github.com/dometto/52d9cb8b45d68bfc7665e5e6683b75a0
-    MATHML_ELEMENTS = [
-      'math', 'maction', 'maligngroup', 'malignmark', 'menclose',
-      'merror', 'mfenced', 'mfrac', 'mglyph', 'mi', 'mlabeledtr',
-      'mlongdiv', 'mmultiscripts', 'mn', 'mo', 'mover', 'mpadded',
-      'mphantom', 'mroot', 'mrow', 'ms', 'mscarries', 'mscarry',
-      'msgroup', 'msline', 'mspace', 'msqrt', 'msrow', 'mstack',
-      'mstyle', 'msub', 'msup', 'msubsup', 'mtable', 'mtd',
-      'mtext', 'mtr', 'munder', 'munderover', 'semantics'
-    ].freeze
+    @@accepted_protocols = ::Loofah::HTML5::SafeList::ACCEPTABLE_PROTOCOLS.to_a.freeze
 
-
-    # Default whitelisted attributes required for MathML. See https://developer.mozilla.org/en-US/docs/Web/MathML/Attribute 
-    MATHML_ATTRS = {
-     'math'=>
-        ['altimg',
-         'altimg-width',
-         'altimg-height',
-         'altimg-valign',
-         'alttext',
-         'dir',
-         'display',
-         'xmlns',
-         'href',
-         'id',
-         'mathbackground',
-         'mathcolor'],
-     'maction'=>
-        ['actiontype', 'selection', 'href', 'id', 'mathbackground', 'mathcolor'],
-     'maligngroup'=>['href', 'id', 'mathbackground', 'mathcolor'],
-     'malignmark'=>['href', 'id', 'mathbackground', 'mathcolor'],
-     'menclose'=>['notation', 'href', 'id', 'mathbackground', 'mathcolor'],
-     'merror'=>['href', 'id', 'mathbackground', 'mathcolor'],
-     'mfenced'=>
-        ['close', 'open', 'separators', 'href', 'id', 'mathbackground', 'mathcolor'],
-     'mfrac'=>
-        ['bevelled',
-         'denomalign',
-         'linethickness',
-         'numalign',
-         'href',
-         'id',
-         'mathbackground',
-         'mathcolor'],
-     'mglyph'=>['height', 'width', 'href', 'id', 'mathbackground', 'mathcolor'],
-     'mi'=>
-        ['dir',
-         'mathbackground',
-         'mathcolor',
-         'mathsize',
-         'mathvariant',
-         'href',
-         'id',
-         'mathbackground',
-         'mathcolor'],
-     'mlabeledtr'=>['columnalign', 'href', 'id', 'mathbackground', 'mathcolor'],
-     'mlongdiv'=>['href', 'id', 'mathbackground', 'mathcolor'],
-     'mmultiscripts'=>
-        ['subscriptshift',
-         'supscriptshift',
-         'href',
-         'id',
-         'mathbackground',
-         'mathcolor'],
-     'mn'=>
-        ['mathbackground',
-         'mathcolor',
-         'mathsize',
-         'mathvariant',
-         'href',
-         'id',
-         'mathbackground',
-         'mathcolor'],
-     'mo'=>
-        ['accent',
-         'dir',
-         'fence',
-         'href',
-         'id',
-         'largeop',
-         'lspace',
-         'mathbackground',
-         'mathcolor',
-         'mathsize',
-         'mathvariant',
-         'maxsize',
-         'minsize',
-         'movablelimits',
-         'rspace',
-         'separator',
-         'stretchy',
-         'symmetric',
-         'href',
-         'id',
-         'mathbackground',
-         'mathcolor'],
-     'mover'=>['accent', 'align', 'href', 'id', 'mathbackground', 'mathcolor'],
-     'mpadded'=>
-        ['depth',
-         'height',
-         'lspace',
-         'voffset',
-         'width',
-         'href',
-         'id',
-         'mathbackground',
-         'mathcolor'],
-     'mphantom'=>['href', 'id', 'mathbackground', 'mathcolor'],
-     'mroot'=>['href', 'id', 'mathbackground', 'mathcolor'],
-     'mrow'=>['dir', 'href', 'id', 'mathbackground', 'mathcolor'],
-     'ms'=>
-        ['dir',
-         'lquote',
-         'mathbackground',
-         'mathcolor',
-         'mathsize',
-         'mathvariant',
-         'rquote',
-         'href',
-         'id',
-         'mathbackground',
-         'mathcolor'],
-     'mscarries'=>['href', 'id', 'mathbackground', 'mathcolor'],
-     'mscarry'=>['href', 'id', 'mathbackground', 'mathcolor'],
-     'msgroup'=>['href', 'id', 'mathbackground', 'mathcolor'],
-     'msline'=>['length', 'href', 'id', 'mathbackground', 'mathcolor'],
-     'mspace'=>['height', 'width', 'href', 'id', 'mathbackground', 'mathcolor'],
-     'msqrt'=>['href', 'id', 'mathbackground', 'mathcolor'],
-     'msrow'=>['href', 'id', 'mathbackground', 'mathcolor'],
-     'mstack'=>['align', 'href', 'id', 'mathbackground', 'mathcolor'],
-     'mstyle'=>
-        ['displaystyle',
-         'scriptlevel',
-         'scriptminsize',
-         'scriptsizemultiplier',
-         'href',
-         'id',
-         'mathbackground',
-         'mathcolor'],
-     'msub'=>['subscriptshift', 'href', 'id', 'mathbackground', 'mathcolor'],
-     'msup'=>['supscriptshift', 'href', 'id', 'mathbackground', 'mathcolor'],
-     'msubsup'=>
-        ['subscriptshift',
-         'supscriptshift',
-         'href',
-         'id',
-         'mathbackground',
-         'mathcolor'],
-     'mtable'=>
-        ['align',
-         'columnalign',
-         'columnlines',
-         'columnspacing',
-         'displaystyle',
-         'frame',
-         'framespacing',
-         'rowalign',
-         'rowlines',
-         'rowspacing',
-         'width',
-         'href',
-         'id',
-         'mathbackground',
-         'mathcolor'],
-     'mtd'=>
-        ['columnalign',
-         'columnspan',
-         'rowalign',
-         'rowspan',
-         'href',
-         'id',
-         'mathbackground',
-         'mathcolor'],
-     'mtext'=>
-        ['dir',
-         'mathbackground',
-         'mathcolor',
-         'mathsize',
-         'mathvariant',
-         'href',
-         'id',
-         'mathbackground',
-         'mathcolor'],
-     'mtr'=>
-        ['columnalign', 'rowalign', 'href', 'id', 'mathbackground', 'mathcolor'],
-     'munder'=>
-        ['accentunder', 'align', 'href', 'id', 'mathbackground', 'mathcolor'],
-     'munderover'=>
-        ['accent',
-         'accentunder',
-         'align',
-         'href',
-         'id',
-         'mathbackground',
-         'mathcolor'],
-     'semantics'=>['href', 'id', 'mathbackground', 'mathcolor']
-    }.freeze
-
-    # Default whitelisted elements.
-    ELEMENTS   = ([
-      'a', 'abbr', 'acronym', 'address', 'area', 'b', 'big',
-      'blockquote', 'br', 'button', 'caption', 'center', 'cite',
-      'code', 'col', 'colgroup', 'dd', 'del', 'dfn', 'dir', 'div',
-      'dl', 'dt', 'em', 'fieldset', 'font', 'form', 'h1', 'h2', 'h3',
-      'h4', 'h5', 'h6', 'hr', 'i', 'img', 'input', 'ins', 'kbd', 'label',
-      'legend', 'li', 'map', 'mark', 'math', 'menu', 'mfrac', 'mi', 'mn',
-      'mo', 'mrow', 'msqrt', 'msubsup', 'msup', 'mtext', 'ol', 'optgroup',
-      'option', 'p', 'pre', 'q', 's', 'samp', 'select', 'small', 'span',
-      'strike', 'strong', 'sub', 'sup', 'table', 'tbody', 'td', 'textarea',
-      'tfoot', 'th', 'thead', 'tr', 'tt', 'u', 'ul', 'var'
-    ] + MATHML_ELEMENTS).freeze
-
-
-    # Default whitelisted attributes.
-    ATTRIBUTES = ({
-        'a'   => ['href'],
-        'img' => ['src'],
-        :all  => ['abbr', 'accept', 'accept-charset',
-                  'accesskey', 'action', 'align', 'alt', 'axis',
-                  'border', 'cellpadding', 'cellspacing', 'char',
-                  'charoff', 'class', 'charset', 'checked', 'cite',
-                  'clear', 'cols', 'colspan', 'color',
-                  'compact', 'coords', 'datetime', 'dir',
-                  'disabled', 'enctype', 'for', 'frame',
-                  'headers', 'height', 'hreflang',
-                  'hspace', 'id', 'ismap', 'label', 'lang',
-                  'longdesc', 'maxlength', 'media', 'method',
-                  'multiple', 'name', 'nohref', 'noshade',
-                  'nowrap', 'prompt', 'readonly', 'rel', 'rev',
-                  'rows', 'rowspan', 'rules', 'scope',
-                  'selected', 'shape', 'size', 'span',
-                  'start', 'summary', 'tabindex', 'target',
-                  'title', 'type', 'usemap', 'valign', 'value',
-                  'vspace', 'width']
-    }.merge(MATHML_ATTRS)).freeze
-
-    # Default whitelisted protocols for URLs.
-    PROTOCOLS  = {
-        'a'    => { 'href' => ['http', 'https', 'mailto', 'ftp', 'irc', 'apt', :relative] },
-        'img'  => { 'src' => ['http', 'https', :relative] },
-        'form' => { 'action' => ['http', 'https', :relative] }
-    }.freeze
-
-    ADD_ATTRIBUTES  = lambda do |env, node|
-      if (add = env[:config][:add_attributes][node.name])
-        add.each do |key, value|
-          node[key] = value
-        end
-      end
+    # This class method is used in the Tag filter to determine whether a link has an acceptable URI scheme.
+    def self.accepted_protocols
+      @@accepted_protocols
     end
 
-    # Default elements whose contents will be removed in addition
-    # to the elements themselve
-    REMOVE_CONTENTS = [
-        'script',
-        'style'
-    ].freeze
+    REMOVE_NODES = ['style', 'script']
 
-    # Default transformers to force @id attributes with 'wiki-' prefix
-    TRANSFORMERS    = [
-        lambda do |env|
-          node = env[:node]
-          return if env[:is_whitelisted] || !node.element?
-          prefix      = env[:config][:id_prefix]
-          found_attrs = %w(id name).select do |key|
-            if (value = node[key])
-              node[key] = value.gsub(/\A(#{prefix})?/, prefix)
+    SCRUB_REMOVE = Loofah::Scrubber.new do |node|
+      node.remove if REMOVE_NODES.include?(node.name)
+    end
+
+    SCRUB_EMPTY_P = Loofah::Scrubber.new do |node|
+      node.remove if node.name == 'p' && node.text.blank? && node.children.empty?
+    end
+
+    attr_reader :id_prefix
+
+    def initialize(to_xml_opts = {})
+      @to_xml_opts = to_xml_opts
+    end
+
+    def clean(data, historical = false)
+      doc = Loofah.fragment(data)
+      doc.scrub!(SCRUB_REMOVE)
+      doc.scrub!(:strip)
+      doc.scrub!(:nofollow) if historical
+      postprocess.each do |scrubber|
+        doc.scrub!(scrubber)
+      end
+      doc.to_xml(@to_xml_opts)
+    end
+
+    private 
+
+    # Additional html transformation tasks to be completed after sanitization
+    def postprocess
+      [wiki_id_scrubber, SCRUB_EMPTY_P].compact
+    end
+
+    # Returns a Loofah::Scrubber if the `id_prefix` attribute is set, or nil otherwise.
+    def wiki_id_scrubber
+      if id_prefix
+        @id_scrubber ||= Loofah::Scrubber.new do |node|
+          if node.name == 'a' && val = node['href']
+            node['href'] = val.gsub(/\A\#(#{id_prefix})?/, '#' + id_prefix) unless node[:class] == 'internal anchorlink' # Don't prefix pure anchor links
+          else
+            %w(id name).each do |key|
+              if (value = node[key])
+                node[key] = value.gsub(/\A(#{id_prefix})?/, id_prefix)
+              end
             end
           end
-          if found_attrs.size > 0
-            ADD_ATTRIBUTES.call(env, node)
-            {}
-          end
-        end,
-        lambda do |env|
-          node = env[:node]
-          if (value = node['href']) && !(node[:class] == 'internal anchorlink') # make an exception for pure anchor links
-            prefix       = env[:config][:id_prefix]
-            node['href'] = value.gsub(/\A\#(#{prefix})?/, '#'+prefix)
-            ADD_ATTRIBUTES.call(env, node)
-            {}
-          end
         end
-    ].freeze
-
-    # Modifies the current Sanitization instance to sanitize older revisions
-    # of pages.
-    #
-    # Returns a Sanitization instance.
-    def self.history_sanitization
-      self.new do |sanitize|
-        sanitize.add_attributes['a'] = { 'rel' => 'nofollow' }
       end
     end
 
-    # Gets an Array of whitelisted HTML elements.  Default: ELEMENTS.
-    attr_reader :elements
-
-    # Gets a Hash describing which attributes are allowed in which HTML
-    # elements.  Default: ATTRIBUTES.
-    attr_reader :attributes
-
-    # Gets a Hash describing which URI protocols are allowed in HTML
-    # attributes.  Default: PROTOCOLS
-    attr_reader :protocols
-
-    # Gets a Hash describing which URI protocols are allowed in HTML
-    # attributes.  Default: TRANSFORMERS
-    attr_reader :transformers
-
-    # Gets or sets a String prefix which is added to ID attributes.
-    # Default: ''
-    attr_accessor :id_prefix
-
-    # Gets a Hash describing HTML attributes that Sanitize should add.
-    # Default: {}
-    attr_reader :add_attributes
-
-    # Gets an Array of element names whose contents will be removed in addition
-    # to the elements themselves. Default: REMOVE_CONTENTS
-    attr_reader :remove_contents
-
-    # Sets a boolean determining whether Sanitize allows HTML comments in the
-    # output.  Default: false.
-    attr_writer :allow_comments
-
-    def initialize
-      @elements        = ELEMENTS.dup
-      @attributes      = ATTRIBUTES.dup
-      @protocols       = PROTOCOLS.dup
-      @transformers    = TRANSFORMERS.dup
-      @add_attributes  = {}
-      @remove_contents = REMOVE_CONTENTS.dup
-      @allow_comments  = false
-      @id_prefix       = ''
-      yield self if block_given?
-    end
-
-    # Determines if Sanitize should allow HTML comments.
-    #
-    # Returns True if comments are allowed, or False.
-    def allow_comments?
-      !!@allow_comments
-    end
-
-    # Builds a Hash of options suitable for Sanitize.clean.
-    #
-    # Returns a Hash.
-    def to_hash
-      { :elements        => elements,
-        :attributes      => attributes,
-        :protocols       => protocols,
-        :add_attributes  => add_attributes,
-        :remove_contents => remove_contents,
-        :allow_comments  => allow_comments?,
-        :transformers    => transformers,
-        :id_prefix       => id_prefix
-      }
-    end
-
-    # Builds a Sanitize instance from the current options.
-    #
-    # Returns a Sanitize instance.
-    def to_sanitize
-      Sanitize.new(to_hash)
-    end
   end
 end
-

--- a/lib/gollum-lib/wiki.rb
+++ b/lib/gollum-lib/wiki.rb
@@ -575,30 +575,6 @@ module Gollum
       @access.refresh
     end
 
-    # Returns an instance of Gollum::Sanitization
-    def sanitization
-      @sanitization ||= ::Gollum::Sanitization.new
-    end
-
-    # Returns an instance of Gollum::Sanitization set to allow elements required for viewing older versions of files
-    def history_sanitization
-      @history_sanitization ||= ::Gollum::Sanitization.history_sanitization
-    end
-
-    # Public: Creates a Sanitize instance
-    #
-    # Returns a Sanitize instance.
-    def sanitizer
-      @sanitizer ||= sanitization.to_sanitize
-    end
-
-    # Public: Creates a Sanitize instance set to allow elements required for viewing older versions of files
-    # 
-    # Returns a Sanitize instance.
-    def history_sanitizer
-      @history_sanitizer ||= history_sanitization.to_sanitize
-    end
-
     def redirects
       if @redirects.nil? || @redirects.stale?
         @redirects = {}.extend(::Gollum::Redirects)
@@ -772,6 +748,13 @@ module Gollum
 
     def inspect
       %(#<#{self.class.name}:#{object_id} #{@repo.path}>)
+    end
+
+    # Public: Creates a Sanitize instance
+    #
+    # Returns a Sanitize instance.
+    def sanitizer
+      @sanitizer ||= Gollum::Sanitization.new(Gollum::Markup.to_xml_opts)
     end
 
     private

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -671,21 +671,21 @@ org
       content = "a [[alpha.jpg|align=#{align}]] b"
       text_align = align
       align = 'end' if align == 'right'
-      output  = "<p>a<span class=\"d-flex flex-justify-#{align} text-#{text_align}\"><span class=\"\"><img src=\"/greek/alpha.jpg\"/></span></span>b</p>"
+      output  = "<p>a<span class=\"d-flex flex-justify-#{align} text-#{text_align}\"><span><img src=\"/greek/alpha.jpg\"/></span></span>b</p>"
       relative_image(content, output)
     end
   end
 
   test "image with float" do
     content = "a\n\n[[alpha.jpg|float]]\n\nb"
-    output  = "<p>a</p><p><span class=\"d-flex float-left pb-4\"><span class=\"\"><img src=\"/greek/alpha.jpg\"/></span></span></p><p>b</p>"
+    output  = "<p>a</p><p><span class=\"d-flex float-left pb-4\"><span><img src=\"/greek/alpha.jpg\"/></span></span></p><p>b</p>"
     relative_image(content, output)
   end
 
   test "image with float and align" do
     %w{left right}.each do |align|
       content = "a\n\n[[alpha.jpg|float, align=#{align}]]\n\nb"
-      output  = "<p>a</p><p><span class=\"d-flex float-#{align} pb-4\"><span class=\"\"><img src=\"/greek/alpha.jpg\"/></span></span></p><p>b</p>"
+      output  = "<p>a</p><p><span class=\"d-flex float-#{align} pb-4\"><span><img src=\"/greek/alpha.jpg\"/></span></span></p><p>b</p>"
       relative_image(content, output)
     end
   end
@@ -704,7 +704,7 @@ org
 
   test "image with align and alt" do
     content = "a [[alpha.jpg|alt=Alpha Dog, align=center]] b"
-    output  ="<p>a<span class=\"d-flex flex-justify-center text-center\"><span class=\"\"><img src=\"/greek/alpha.jpg\" alt=\"Alpha Dog\"/></span></span>b</p>"
+    output  ="<p>a<span class=\"d-flex flex-justify-center text-center\"><span><img src=\"/greek/alpha.jpg\" alt=\"Alpha Dog\"/></span></span>b</p>"
     relative_image(content, output)
   end
 


### PR DESCRIPTION
Sanitize is no longer being maintained for JRuby (see #320). [Loofah](https://github.com/flavorjones/loofah) is the sanitizer used in the rails asset pipeline. It wasn't all that difficult to plug it in and get the tests passing, and I think it's actually a bit easier to understand what's happening than with Sanitize.

Loofah has some sane defaults for safe HTML5 elements: https://github.com/flavorjones/loofah/blob/master/lib/loofah/html5/safelist.rb#L47, so we don't have to maintain that ourselves. End users can still override these settings by overriding `Loofah::HTML5::SafeList`.