### PR TITLE
Restore Java gemfile

### DIFF
--- a/adapter_dependencies.rb
+++ b/adapter_dependencies.rb
@@ -1,0 +1,5 @@
+if RUBY_PLATFORM == 'java' then
+  DEFAULT_ADAPTER_REQ = ['gollum-rjgit_adapter', '>= 0.5.1', '~> 0.5.1']
+else
+  DEFAULT_ADAPTER_REQ = ['gollum-rugged_adapter', '>= 0.99.4', '~> 0.99.4']
+end

--- a/adapter_dependencies.rb
+++ b/adapter_dependencies.rb
@@ -1,3 +1,5 @@
+# Set the default git adapter for use in gollum-lib.gemspec and gollum-lib_java.gemspec
+
 if RUBY_PLATFORM == 'java' then
   DEFAULT_ADAPTER_REQ = ['gollum-rjgit_adapter', '>= 0.5.1', '~> 0.5.1']
 else

--- a/gollum-lib.gemspec
+++ b/gollum-lib.gemspec
@@ -1,8 +1,4 @@
 require File.join(File.dirname(__FILE__), 'gemspec.rb')
+require File.join(File.dirname(__FILE__), 'adapter_dependencies.rb')
 require File.join(File.dirname(__FILE__), 'lib', 'gollum-lib', 'version.rb')
-  if RUBY_PLATFORM == 'java' then
-    default_adapter = ['gollum-rjgit_adapter', '>= 0.5.1', '~> 0.5.1']
-  else
-    default_adapter = ['gollum-rugged_adapter', '>= 0.99.4', '~> 0.99.4']
-  end
-Gem::Specification.new &specification(Gollum::Lib::VERSION, default_adapter)
+Gem::Specification.new &specification(Gollum::Lib::VERSION, DEFAULT_ADAPTER_REQ)

--- a/gollum-lib_java.gemspec
+++ b/gollum-lib_java.gemspec
@@ -1,4 +1,4 @@
 require File.join(File.dirname(__FILE__), 'gemspec.rb')
+require File.join(File.dirname(__FILE__), 'adapter_dependencies.rb')
 require File.join(File.dirname(__FILE__), 'lib', 'gollum-lib', 'version.rb')
-default_adapter = ['gollum-rjgit_adapter', '~> 0.5.1']
-Gem::Specification.new &specification(Gollum::Lib::VERSION, default_adapter, "java") 
+Gem::Specification.new &specification(Gollum::Lib::VERSION, DEFAULT_ADAPTER_REQ, "java") 

--- a/gollum-lib_java.gemspec
+++ b/gollum-lib_java.gemspec
@@ -1,0 +1,4 @@
+require File.join(File.dirname(__FILE__), 'gemspec.rb')
+require File.join(File.dirname(__FILE__), 'lib', 'gollum-lib', 'version.rb')
+default_adapter = ['gollum-rjgit_adapter', '~> 0.5.1']
+Gem::Specification.new &specification(Gollum::Lib::VERSION, default_adapter, "java") 


### PR DESCRIPTION
I removed the separate Java gemspec because the rjgit_adapter is already set as default in the 'normal' `gollum-lib.gemspec`. However, I just realized the reason for having the second gemspec is to facilitate building the java version of the gem -- even though in normal cases, the dependency chain is resolved through `gollum-lib.gemspec`. So I've re-added the Java gemspec.

What annoys me, however, is that we have to keep track of the rjgit_adapter dependency in two places: in `gollum-lib.gemspec`, and `gollum-lib_java.gemspec`. The only way I can see around that is have a *third* file, `adapter_dependencies.rb` or some such, in which we define the requirements, and load that file from both gemspec files. Does that seem better or worse?