### PR TITLE
Fix titles

### DIFF
--- a/gemspec.rb
+++ b/gemspec.rb
@@ -43,7 +43,7 @@ def specification(version, default_adapter, platform = nil)
     s.add_development_dependency 'bibtex-ruby', '~> 4.3'
     s.add_development_dependency 'citeproc-ruby', '~> 1.1'
     s.add_development_dependency 'unicode_utils', '~> 1.4.0' # required by citeproc-ruby on ruby < 2.4
-    s.add_development_dependency 'rake', '>= 12.3.3'
+    s.add_development_dependency 'rake', '~> 12.3', '>= 12.3.3'
     s.add_development_dependency 'pry', '~> 0.10.1'
     # required by pry
     s.add_development_dependency 'rb-readline', '~> 0.5.1'

--- a/lib/gollum-lib/markups.rb
+++ b/lib/gollum-lib/markups.rb
@@ -58,8 +58,7 @@ module Gollum
     if gem_exists?('pandoc-ruby')
       GitHub::Markup::Markdown::MARKDOWN_GEMS.delete('kramdown')
       GitHub::Markup::Markdown::MARKDOWN_GEMS['pandoc-ruby'] = proc { |content|
-          result = PandocRuby.convert(content, :s, :from => :markdown, :to => :html, :filter => 'pandoc-citeproc')
-          Nokogiri::HTML::Document.parse(result).at('body').inner_html
+          PandocRuby.convert(content, :from => :markdown, :to => :html, :filter => 'pandoc-citeproc')
       }
     else
       GitHub::Markup::Markdown::MARKDOWN_GEMS['kramdown'] = proc { |content|

--- a/lib/gollum-lib/markups.rb
+++ b/lib/gollum-lib/markups.rb
@@ -58,7 +58,8 @@ module Gollum
     if gem_exists?('pandoc-ruby')
       GitHub::Markup::Markdown::MARKDOWN_GEMS.delete('kramdown')
       GitHub::Markup::Markdown::MARKDOWN_GEMS['pandoc-ruby'] = proc { |content|
-          PandocRuby.convert(content, :s, :from => :markdown, :to => :html, :filter => 'pandoc-citeproc')
+          result = PandocRuby.convert(content, :s, :from => :markdown, :to => :html, :filter => 'pandoc-citeproc')
+          Nokogiri::HTML::Document.parse(result).at('body').inner_html
       }
     else
       GitHub::Markup::Markdown::MARKDOWN_GEMS['kramdown'] = proc { |content|


### PR DESCRIPTION
It turns out that when rendering markdown with Pandoc, the result was a fully formed HTML document, rather than just the body's inner html, which is what we require. This was causing some of the Nokogiri operations we do elsewhere in the filter chain and in gollum to fail, resulting (perhaps amongst other bugs) in the bug that h1 title's weren't being found when using Pandoc (see https://github.com/gollum/gollum/issues/1484).

This PR remedies this by extracting the body from the document that pandoc renders.