### PR TITLE
Github compatibility option

### DIFF
--- a/lib/gollum-lib/file.rb
+++ b/lib/gollum-lib/file.rb
@@ -12,7 +12,7 @@ module Gollum
       #
       # query     - The String path to match.
       # entry     - The BlobEntry to check against.
-      # global_match - If true, find a File matching path's filename, but not it's directory (so anywhere in the repo)
+      # global_match - If true, find a File matching path's filename, but not its directory (so anywhere in the repo)
       def path_match(query, entry, global_match = false)
         query == ::File.join('/', entry.path)
       end

--- a/lib/gollum-lib/file.rb
+++ b/lib/gollum-lib/file.rb
@@ -12,8 +12,8 @@ module Gollum
       #
       # query     - The String path to match.
       # entry     - The BlobEntry to check against.
-      # global_match - If true, find a File matching path's filename, but not it's directory (so anywhere in the repo)
-      # sub_spaces   - GitHub compatibility: substitutes - for spaces when comparing filenames.
+      # global_match - (Not implemented for File) If true, find a File matching path's filename, but not it's directory (so anywhere in the repo)
+      # sub_spaces   - (Not implemented for File) Substitutes spaces for - when comparing filenames.
       def path_match(query, entry, global_match = false, sub_spaces = false)
         query == ::File.join('/', entry.path)
       end

--- a/lib/gollum-lib/file.rb
+++ b/lib/gollum-lib/file.rb
@@ -12,7 +12,9 @@ module Gollum
       #
       # query     - The String path to match.
       # entry     - The BlobEntry to check against.
-      def path_match(query, entry, global_match = false)
+      # global_match - If true, find a File matching path's filename, but not it's directory (so anywhere in the repo)
+      # sub_spaces   - GitHub compatibility: substitutes - for spaces when comparing filenames.
+      def path_match(query, entry, global_match = false, sub_spaces = false)
         query == ::File.join('/', entry.path)
       end
     end
@@ -24,11 +26,13 @@ module Gollum
     # version - The String version ID to find.
     # try_on_disk - If true, try to return just a reference to a file
     #               that exists on the disk.
+    # global_match - If true, find a File matching path's filename, but not it's directory (so anywhere in the repo)
+    # sub_spaces   - GitHub compatibility: substitutes - for spaces when comparing filenames.
     #
     # Returns a Gollum::File or nil if the file could not be found. Note
     # that if you specify try_on_disk=true, you may or may not get a file
     # for which on_disk? is actually true.
-    def self.find(wiki, path, version, try_on_disk = false, global_match = false)
+    def self.find(wiki, path, version, try_on_disk = false, global_match = false, sub_spaces = false)
       map = wiki.tree_map_for(version.to_s)
 
       query_path = Pathname.new(::File.join(['/', wiki.page_file_dir, path].compact)).cleanpath.to_s
@@ -36,7 +40,7 @@ module Gollum
 
       begin
         entry = map.detect do |entry|
-          path_match(query_path, entry, global_match)
+          path_match(query_path, entry, global_match, sub_spaces)
         end
         entry ? self.new(wiki, entry.blob(wiki.repo), entry.dir, version, try_on_disk) : nil
       rescue Gollum::Git::NoSuchShaFound

--- a/lib/gollum-lib/file.rb
+++ b/lib/gollum-lib/file.rb
@@ -12,7 +12,7 @@ module Gollum
       #
       # query     - The String path to match.
       # entry     - The BlobEntry to check against.
-      # global_match - (Not implemented for File) If true, find a File matching path's filename, but not it's directory (so anywhere in the repo)
+      # global_match - If true, find a File matching path's filename, but not it's directory (so anywhere in the repo)
       def path_match(query, entry, global_match = false)
         query == ::File.join('/', entry.path)
       end

--- a/lib/gollum-lib/file.rb
+++ b/lib/gollum-lib/file.rb
@@ -13,8 +13,7 @@ module Gollum
       # query     - The String path to match.
       # entry     - The BlobEntry to check against.
       # global_match - (Not implemented for File) If true, find a File matching path's filename, but not it's directory (so anywhere in the repo)
-      # sub_spaces   - (Not implemented for File) Substitutes spaces for - when comparing filenames.
-      def path_match(query, entry, global_match = false, sub_spaces = false)
+      def path_match(query, entry, global_match = false)
         query == ::File.join('/', entry.path)
       end
     end
@@ -27,12 +26,11 @@ module Gollum
     # try_on_disk - If true, try to return just a reference to a file
     #               that exists on the disk.
     # global_match - If true, find a File matching path's filename, but not it's directory (so anywhere in the repo)
-    # sub_spaces   - GitHub compatibility: substitutes - for spaces when comparing filenames.
     #
     # Returns a Gollum::File or nil if the file could not be found. Note
     # that if you specify try_on_disk=true, you may or may not get a file
     # for which on_disk? is actually true.
-    def self.find(wiki, path, version, try_on_disk = false, global_match = false, sub_spaces = false)
+    def self.find(wiki, path, version, try_on_disk = false, global_match = false)
       map = wiki.tree_map_for(version.to_s)
 
       query_path = Pathname.new(::File.join(['/', wiki.page_file_dir, path].compact)).cleanpath.to_s
@@ -40,7 +38,7 @@ module Gollum
 
       begin
         entry = map.detect do |entry|
-          path_match(query_path, entry, global_match, sub_spaces)
+          path_match(query_path, entry, global_match)
         end
         entry ? self.new(wiki, entry.blob(wiki.repo), entry.dir, version, try_on_disk) : nil
       rescue Gollum::Git::NoSuchShaFound

--- a/lib/gollum-lib/filter/remote_code.rb
+++ b/lib/gollum-lib/filter/remote_code.rb
@@ -20,7 +20,7 @@ class Gollum::Filter::RemoteCode < Gollum::Filter
 
       # Detect local file
       if protocol.nil?
-        if (file = @markup.find_file(uri, @markup.wiki.ref))
+        if (file = @markup.wiki.file(uri, @markup.wiki.ref))
           contents = file.raw_data
         else
           # How do we communicate a render error?

--- a/lib/gollum-lib/filter/tags.rb
+++ b/lib/gollum-lib/filter/tags.rb
@@ -242,8 +242,8 @@ class Gollum::Filter::Tags < Gollum::Filter
   def find_page_from_path(path)
     if Pathname.new(path).relative?
       page = @markup.wiki.page(::File.join(@markup.dir, path))
-      if page.nil? && @markup.wiki.global_tag_lookup # 4.x link compatibility option. Slow!
-        page = @markup.wiki.page(path, nil, true)
+      if page.nil? && (@markup.wiki.global_tag_lookup || @markup.wiki.github_tag_compatibility)# 4.x link compatibility option. Slow!
+        page = @markup.wiki.page(path, nil, @markup.wiki.global_tag_lookup, @markup.wiki.github_tag_compatibility)
       end
       page
     else

--- a/lib/gollum-lib/markup.rb
+++ b/lib/gollum-lib/markup.rb
@@ -162,20 +162,6 @@ module Gollum
       process_chain(data, filter_chain, &block)
     end
 
-    # Find the given file in the repo.
-    #
-    # name - The String absolute or relative path of the file.
-    #
-    # Returns the Gollum::File or nil if none was found.
-    def find_file(name, version=@version)
-      if name =~ /^\//
-        @wiki.file(name[1..-1], version)
-      else
-        path = @dir == '.' ? name : ::File.join(@dir, name)
-        @wiki.file(path, version)
-      end
-    end
-
     # Hook for getting the formatted value of extracted tag data.
     #
     # type - Symbol value identifying what type of data is being extracted.

--- a/lib/gollum-lib/page.rb
+++ b/lib/gollum-lib/page.rb
@@ -10,7 +10,7 @@ module Gollum
       #
       # query     - The String path to match.
       # entry     - The BlobEntry to check against.
-      # global_match - If true, find a File matching path's filename, but not it's directory (so anywhere in the repo)
+      # global_match - If true, find a File matching path's filename, but not its directory (so anywhere in the repo)
       def path_match(query, entry, global_match = false)
         return false if "#{entry.name}".empty?
         return false unless valid_extension?(entry.name)

--- a/lib/gollum-lib/page.rb
+++ b/lib/gollum-lib/page.rb
@@ -11,7 +11,7 @@ module Gollum
       # query     - The String path to match.
       # entry     - The BlobEntry to check against.
       # global_match - If true, find a File matching path's filename, but not it's directory (so anywhere in the repo)
-      # sub_spaces   - GitHub compatibility: substitutes - for spaces when comparing filenames.
+      # sub_spaces   - GitHub compatibility: substitutes spaces for - when comparing filenames.
       def path_match(query, entry, global_match = false, sub_spaces = false)
         return false if "#{entry.name}".empty?
         return false unless valid_extension?(entry.name)
@@ -19,7 +19,7 @@ module Gollum
         match_path = ::File.join([
           '/',
           global_match ? nil : entry.dir,
-          sub_spaces ? entry_name.gsub(' ', '-') : entry_name
+          sub_spaces ? entry_name.gsub('-', ' ') : entry_name
         ].compact)
         query == match_path
       end

--- a/lib/gollum-lib/page.rb
+++ b/lib/gollum-lib/page.rb
@@ -10,11 +10,18 @@ module Gollum
       #
       # query     - The String path to match.
       # entry     - The BlobEntry to check against.
-      def path_match(query, entry, global_match = false)
+      # global_match - If true, find a File matching path's filename, but not it's directory (so anywhere in the repo)
+      # sub_spaces   - GitHub compatibility: substitutes - for spaces when comparing filenames.
+      def path_match(query, entry, global_match = false, sub_spaces = false)
         return false if "#{entry.name}".empty?
         return false unless valid_extension?(entry.name)
-        entry_name = valid_extension?(query) ? entry.name : strip_filename(entry.name)        
-        query == (global_match ? ::File.join('/', entry_name) : ::File.join('/', entry.dir, entry_name))
+        entry_name = valid_extension?(query) ? entry.name : strip_filename(entry.name)     
+        match_path = ::File.join([
+          '/',
+          global_match ? nil : entry.dir,
+          sub_spaces ? entry_name.gsub(' ', '-') : entry_name
+        ].compact)
+        query == match_path
       end
     end
 

--- a/lib/gollum-lib/page.rb
+++ b/lib/gollum-lib/page.rb
@@ -11,15 +11,14 @@ module Gollum
       # query     - The String path to match.
       # entry     - The BlobEntry to check against.
       # global_match - If true, find a File matching path's filename, but not it's directory (so anywhere in the repo)
-      # sub_spaces   - GitHub compatibility: substitutes spaces for - when comparing filenames.
-      def path_match(query, entry, global_match = false, sub_spaces = false)
+      def path_match(query, entry, global_match = false)
         return false if "#{entry.name}".empty?
         return false unless valid_extension?(entry.name)
         entry_name = valid_extension?(query) ? entry.name : strip_filename(entry.name)     
         match_path = ::File.join([
           '/',
           global_match ? nil : entry.dir,
-          sub_spaces ? entry_name.gsub('-', ' ') : entry_name
+          entry_name
         ].compact)
         query == match_path
       end

--- a/lib/gollum-lib/wiki.rb
+++ b/lib/gollum-lib/wiki.rb
@@ -94,7 +94,7 @@ module Gollum
     #           :user_icons    - Enable user icons on the history page. [gravatar, identicon, none].
     #                            Default: none
     #           :global_tag_lookup        - Enable 4.x compatibility behavior for links
-    #           :github_tag_compatibility - Enable github compatibility behavior for links (substitute - for spaces in page names)
+    #           :hyphened_tag_lookup - Spaces in tag paths are treated as dashes (-)
     #           :css           - Include the custom.css file from the repo.
     #           :emoji         - Parse and interpret emoji tags (e.g. :heart:).
     #           :h1_title      - Concatenate all h1's on a page to form the
@@ -130,7 +130,7 @@ module Gollum
       @universal_toc        = options.fetch :universal_toc, false
       @mathjax              = options.fetch :mathjax, false
       @global_tag_lookup    = options.fetch :global_tag_lookup, false
-      @github_tag_compatibility = options.fetch :github_tag_compatibility, false
+      @hyphened_tag_lookup = options.fetch :hyphened_tag_lookup, false
       @css                  = options.fetch :css, false
       @emoji                = options.fetch :emoji, false
       @critic_markup        = options.fetch :critic_markup, false
@@ -162,11 +162,10 @@ module Gollum
     # path    - The String path to the the wiki page (may or may not include file extension).
     # version - The String version ID to find (default: @ref).
     # global_match - If true, find a File matching path's filename, but not it's directory (so anywhere in the repo)
-    # sub_spaces   - GitHub compatibility: substitutes spaces for - when comparing filenames.
     #
     # Returns a Gollum::Page or nil if no matching page was found.
-    def page(path, version = nil, global_match = false, sub_spaces = false)
-      ::Gollum::Page.find(self, path, version.nil? ? @ref : version, false, global_match, sub_spaces)
+    def page(path, version = nil, global_match = false)
+      ::Gollum::Page.find(self, path, version.nil? ? @ref : version, false, global_match)
     end
 
     # Public: Get the static file for a given name.
@@ -592,8 +591,8 @@ module Gollum
     # Enable 4.x compatibility behavior for links
     attr_reader :global_tag_lookup
     
-    # Enable github compatibility behavior for links (substitute spaces for - in page names)
-    attr_reader :github_tag_compatibility
+    # Spaces in tag paths are treated as dashes (-)
+    attr_reader :hyphened_tag_lookup
 
     # Toggles file upload functionality.
     attr_reader :allow_uploads

--- a/lib/gollum-lib/wiki.rb
+++ b/lib/gollum-lib/wiki.rb
@@ -93,8 +93,8 @@ module Gollum
     #           :mathjax       - Set to false to disable mathjax.
     #           :user_icons    - Enable user icons on the history page. [gravatar, identicon, none].
     #                            Default: none
-    #           :show_all      - Show all files in file view, not just valid pages.
-    #                            Default: false
+    #           :global_tag_lookup        - Enable 4.x compatibility behavior for links
+    #           :github_tag_compatibility - Enable github compatibility behavior for links (substitute - for spaces in page names)
     #           :css           - Include the custom.css file from the repo.
     #           :emoji         - Parse and interpret emoji tags (e.g. :heart:).
     #           :h1_title      - Concatenate all h1's on a page to form the
@@ -129,8 +129,8 @@ module Gollum
       @ref                  = options.fetch :ref, self.class.default_ref
       @universal_toc        = options.fetch :universal_toc, false
       @mathjax              = options.fetch :mathjax, false
-      @show_all             = options.fetch :show_all, false
       @global_tag_lookup    = options.fetch :global_tag_lookup, false
+      @github_tag_compatibility = options.fetch :github_tag_compatibility, false
       @css                  = options.fetch :css, false
       @emoji                = options.fetch :emoji, false
       @critic_markup        = options.fetch :critic_markup, false
@@ -161,10 +161,12 @@ module Gollum
     #
     # path    - The String path to the the wiki page (may or may not include file extension).
     # version - The String version ID to find (default: @ref).
+    # global_match - If true, find a File matching path's filename, but not it's directory (so anywhere in the repo)
+    # sub_spaces   - GitHub compatibility: substitutes - for spaces when comparing filenames.
     #
     # Returns a Gollum::Page or nil if no matching page was found.
-    def page(path, version = nil, global_match = false)
-      ::Gollum::Page.find(self, path, version.nil? ? @ref : version, false, global_match)
+    def page(path, version = nil, global_match = false, sub_spaces = false)
+      ::Gollum::Page.find(self, path, version.nil? ? @ref : version, false, global_match, sub_spaces)
     end
 
     # Public: Get the static file for a given name.
@@ -589,6 +591,9 @@ module Gollum
 
     # Enable 4.x compatibility behavior for links
     attr_reader :global_tag_lookup
+    
+    # Enable github compatibility behavior for links (substitute - for spaces in page names)
+    attr_reader :github_tag_compatibility
 
     # Toggles file upload functionality.
     attr_reader :allow_uploads

--- a/lib/gollum-lib/wiki.rb
+++ b/lib/gollum-lib/wiki.rb
@@ -162,7 +162,7 @@ module Gollum
     # path    - The String path to the the wiki page (may or may not include file extension).
     # version - The String version ID to find (default: @ref).
     # global_match - If true, find a File matching path's filename, but not it's directory (so anywhere in the repo)
-    # sub_spaces   - GitHub compatibility: substitutes - for spaces when comparing filenames.
+    # sub_spaces   - GitHub compatibility: substitutes spaces for - when comparing filenames.
     #
     # Returns a Gollum::Page or nil if no matching page was found.
     def page(path, version = nil, global_match = false, sub_spaces = false)
@@ -592,7 +592,7 @@ module Gollum
     # Enable 4.x compatibility behavior for links
     attr_reader :global_tag_lookup
     
-    # Enable github compatibility behavior for links (substitute - for spaces in page names)
+    # Enable github compatibility behavior for links (substitute spaces for - in page names)
     attr_reader :github_tag_compatibility
 
     # Toggles file upload functionality.

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -774,7 +774,12 @@ org
     wiki.instance_variable_set('@github_tag_compatibility', true)
     index = wiki.repo.index
     index.add('Linked-Relative.md', 'Hobbits are nice')
-    index.add('Foo', 'a [[Linked Relative]] b')
+    index.add('Foo.md', 'a [[Linked Relative]] b')
+    index.commit('Add Foo')
+    
+    page   = wiki.page("Foo")
+    output = Gollum::Markup.new(page).render
+    assert_html_equal %{<p>a <a class="internal present" href="/Linked-Relative.md">Linked Relative</a> b</p>}, output   
   end
   
   test "page link with relative path" do

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -769,9 +769,22 @@ org
     assert_html_equal %{<p>a <a class="internal present" href="/LinkedRelative.md">LinkedRelative</a> b</p>}, output 
   end
   
-  test "page link with github compatibility" do
+  test "hyphenated file link compatibility" do
     wiki = @wiki.dup
-    wiki.instance_variable_set('@github_tag_compatibility', true)
+    wiki.instance_variable_set('@hyphened_tag_lookup', true)
+    index = wiki.repo.index
+    index.add('Linked-PDF.pdf', 'Hobbits are nice')
+    index.add('Foo.md', 'a [[Linked PDF.pdf]] b')
+    index.commit('Add Foo')
+    
+    page   = wiki.page("Foo")
+    output = Gollum::Markup.new(page).render
+    assert_html_equal %{<p>a <a href=\"/Linked-PDF.pdf\">Linked-PDF.pdf</a> b</p>\n}, output   
+  end
+    
+  test "hyphenated page link compatibility" do
+    wiki = @wiki.dup
+    wiki.instance_variable_set('@hyphened_tag_lookup', true)
     index = wiki.repo.index
     index.add('Linked-Relative.md', 'Hobbits are nice')
     index.add('Foo.md', 'a [[Linked Relative]] b')

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -769,6 +769,14 @@ org
     assert_html_equal %{<p>a <a class="internal present" href="/LinkedRelative.md">LinkedRelative</a> b</p>}, output 
   end
   
+  test "page link with github compatibility" do
+    wiki = @wiki.dup
+    wiki.instance_variable_set('@github_tag_compatibility', true)
+    index = wiki.repo.index
+    index.add('Linked-Relative.md', 'Hobbits are nice')
+    index.add('Foo', 'a [[Linked Relative]] b')
+  end
+  
   test "page link with relative path" do
     index = @wiki.repo.index
     index.add('LinkedRelative.md', 'Hobbits are nice')


### PR DESCRIPTION
This feature enables a 'fallback' option: when linking `[[Bilbo Baggins]]` and it is not found, look for `[[Bilbo-Baggins]]`. Provides backwards compatibility with 4.x and github. Questions:

* do we want this?
* if so, do we want this and `global_tag_lookup` to be different options, or the same?
   * could also make them separate options in gollum-lib, but have one `--tag-compatibility' (? name) switch in gollum which enables them both.