### PR TITLE
Perform hyphen substitution outside of Tag filter

### DIFF
--- a/lib/gollum-lib/file.rb
+++ b/lib/gollum-lib/file.rb
@@ -23,7 +23,14 @@ module Gollum
       # hyphened_tags  - If true, replace spaces in match_path with hyphens.
       # case_insensitive - If true, compare query and match_path case-insensitively
       def path_compare(query, match_path, hyphened_tags, case_insensitive)
-        (hyphened_tags ? match_path.gsub(' ', '-') : match_path).send(case_insensitive ? :casecmp? : :==, query)
+        if hyphened_tags
+          final_query = query.gsub(' ', '-')
+          final_match = match_path.gsub(' ', '-')
+        else
+          final_query = query
+          final_match = match_path
+        end
+        final_match.send(case_insensitive ? :casecmp? : :==, final_query)
       end
     end
 

--- a/lib/gollum-lib/filter/tags.rb
+++ b/lib/gollum-lib/filter/tags.rb
@@ -240,15 +240,14 @@ class Gollum::Filter::Tags < Gollum::Filter
   #
   # Returns a Gollum::Page instance if a page is found, or nil otherwise
   def find_page_or_file_from_path(path, kind = :page)
-    query = query_for_path(path)
-    if Pathname.new(query).relative?
-      result = @markup.wiki.send(kind, ::File.join(@markup.dir, query))
+    if Pathname.new(path).relative?
+      result = @markup.wiki.send(kind, ::File.join(@markup.dir, path))
       if result.nil? && @markup.wiki.global_tag_lookup # 4.x link compatibility option. Slow!
-        result = @markup.wiki.send(kind, query, nil, true)
+        result = @markup.wiki.send(kind, path, nil, true)
       end
       result
     else
-      @markup.wiki.send(kind, query)
+      @markup.wiki.send(kind, path)
     end
   end
 
@@ -357,9 +356,5 @@ class Gollum::Filter::Tags < Gollum::Filter
     attrs[:height] = options[:height] if options[:height] =~ /^\d+(\.\d+)?(em|px)$/
 
     return classes, attrs, containered
-  end
-  
-  def query_for_path(path)
-    @markup.wiki.hyphened_tag_lookup ? path.gsub(' ', '-') : path
   end
 end

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -799,6 +799,8 @@ org
     page2   = wiki.page("Zoo")
     output = Gollum::Markup.new(page2).render
     assert_html_equal %{<p>a <a class="internal present" href="/Some%20Spaced%20Filename.md">Some Spaced Filename</a> b</p>}, output    
+    
+    assert_not_nil wiki.page('Some Spaced Filename')
   end
   
   test "case insensitive page links" do


### PR DESCRIPTION
Came across a (hopefully final) bug when testing with the `--hyphened-tag-lookup` option: it was working fine within link tags, but upon actually clicking the link, the file would not be found. This was because substituting the hyphens in the link was happening in the Tag filter, and not in `Page.path_match`. So Page lookup outside of the Tag filter effectively didn't have the compatibility option enabled. Fixed and now everything seems to be working nicely!