### PR TITLE
Add base_path to /gollum/emoji

### DIFF
--- a/lib/gollum-lib/filter/emoji.rb
+++ b/lib/gollum-lib/filter/emoji.rb
@@ -26,7 +26,8 @@ class Gollum::Filter::Emoji < Gollum::Filter
   end
 
   def process(data)
-    data.gsub! process_pattern, %q(<img src="/gollum/emoji/\k<name>" alt="\k<name>" class="emoji">)
+    src = ::File.join(@markup.wiki.base_path, '/gollum/emoji/\\k<name>')
+    data.gsub! process_pattern, %Q(<img src="#{src}" alt="\\k<name>" class="emoji">)
     data
   end
 

--- a/test/filter/test_emoji.rb
+++ b/test/filter/test_emoji.rb
@@ -5,10 +5,16 @@ require File.expand_path(path)
 context "Gollum::Filter::Emoji" do
   setup do
     @filter = Gollum::Filter::Emoji.new(Gollum::Markup.new(mock_page))
+    page = mock_page(base_path: '/base_path')
+    @filter_base_path = Gollum::Filter::Emoji.new(Gollum::Markup.new(page))
   end
 
   def filter(content)
     @filter.process(@filter.extract(content))
+  end
+
+  def filter_base_path(content)
+    @filter_base_path.process(@filter_base_path.extract(content))
   end
 
   test "processing emoji tags" do
@@ -16,5 +22,6 @@ context "Gollum::Filter::Emoji" do
     assert_equal filter(':point_up_tone3:'), %q(<img src="/gollum/emoji/point_up_tone3" alt="point_up_tone3" class="emoji">)
     assert_equal filter(':oggy_was_here:'), ':oggy_was_here:'
     assert_equal filter('rake app\:shell:install'), 'rake app:shell:install'
+    assert_equal filter_base_path(':heart:'), %q(<img src="/base_path/gollum/emoji/heart" alt="heart" class="emoji">)
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -68,6 +68,7 @@ end
 
 class MockWiki
   def initialize(bare = false)
+    @base_path = '/'
     @repo_is_bare = bare
   end
 
@@ -83,6 +84,7 @@ class MockWiki
     TEST_DIR
   end
 
+  attr_reader :base_path
   attr_reader :repo_is_bare
 end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -67,9 +67,9 @@ def commit_details
 end
 
 class MockWiki
-  def initialize(bare = false)
-    @base_path = '/'
+  def initialize(bare = false, options = {})
     @repo_is_bare = bare
+    @base_path = options.fetch :base_path, '/'
   end
 
   def file(path)
@@ -84,13 +84,13 @@ class MockWiki
     TEST_DIR
   end
 
-  attr_reader :base_path
   attr_reader :repo_is_bare
+  attr_reader :base_path
 end
 
-def mock_page(format = nil, data = nil)
+def mock_page(format = nil, data = nil, **wiki_options)
   OpenStruct.new(
-      :wiki => MockWiki.new,
+      :wiki => MockWiki.new(nil, wiki_options),
       :filename => 'Name.md',
       :text_data => data || "# Title\nData",
       :version => nil,


### PR DESCRIPTION
Briefly confirmed that this PR does not break the behavior when `base_path` is `Nil`.