### PR TITLE
add support for a time attribute in the options hash on comitting

### DIFF
--- a/lib/gollum-lib/committer.rb
+++ b/lib/gollum-lib/committer.rb
@@ -54,7 +54,7 @@ module Gollum
       @actor ||= begin
         @options[:name]  = @wiki.default_committer_name if @options[:name].nil?
         @options[:email] = @wiki.default_committer_email if @options[:email].nil?
-        Gollum::Git::Actor.new(@options[:name], @options[:email])
+        Gollum::Git::Actor.new(@options[:name], @options[:email], @options[:time])
       end
     end
 

--- a/test/test_committer.rb
+++ b/test/test_committer.rb
@@ -25,18 +25,23 @@ context "Wiki" do
     committer      = Gollum::Committer.new(@wiki, commit)
     assert_equal name, committer.actor.name
     assert_equal email, committer.actor.email
+    assert_equal nil, committer.actor.time
 
     commit[:name]  = 'bob'
     commit[:email] = nil
+    commit[:time] = nil
     committer      = Gollum::Committer.new(@wiki, commit)
     assert_equal 'bob', committer.actor.name
     assert_equal email, committer.actor.email
+    assert_equal nil, committer.actor.time
 
     commit[:name]  = nil
     commit[:email] = 'foo@bar.com'
+    commit[:time] = Time.parse('2020-02-14')
     committer      = Gollum::Committer.new(@wiki, commit)
     assert_equal name, committer.actor.name
     assert_equal 'foo@bar.com', committer.actor.email
+    assert_equal Time.parse('2020-02-14'), committer.actor.time
   end
 
   test "yield after_commit callback" do


### PR DESCRIPTION
This time attribute can be used to create commits with a specified timestamp. See #373 for discussion.