### PR TITLE
Use the currently active page name in Series macro instead of subpage name

### DIFF
--- a/lib/gollum-lib/macro.rb
+++ b/lib/gollum-lib/macro.rb
@@ -25,6 +25,10 @@ module Gollum
       "<p class=\"gollum-error\">#{s}</p>"
     end
 
+    def active_page
+      return @page.parent_page || @page
+    end
+
     # The special class we reserve for only the finest of screwups.  The
     # underscore is to make sure nobody can define a real, callable macro
     # with the same name, because that would be... exciting.

--- a/lib/gollum-lib/macro/series.rb
+++ b/lib/gollum-lib/macro/series.rb
@@ -3,7 +3,7 @@ module Gollum
 
     class Series < Gollum::Macro
       def render(series_prefix = "")
-      	raise "This page's name does not match the prefix '#{series_prefix}'" unless @page.name =~ /^#{series_prefix}/
+      	raise "This page's name does not match the prefix '#{series_prefix}'" unless active_page.name =~ /^#{series_prefix}/
       	render_links(*find_series(series_prefix))
       end
 
@@ -21,7 +21,7 @@ module Gollum
       	dir = @wiki.pages.select {|page| ::File.dirname(page.path) == ::File.dirname(@page.path)}
       	dir.select! {|page| page.name =~ /\A#{series_prefix}/ } unless series_prefix.empty?
       	dir.sort_by! {|page| page.name}
-      	self_index = dir.find_index {|page| page.name == @page.name}
+      	self_index = dir.find_index {|page| page.name == active_page.name}
       	if self_index > 0
           return dir[self_index-1], dir[self_index+1]
       	else

--- a/test/test_macros.rb
+++ b/test/test_macros.rb
@@ -74,6 +74,18 @@ context "Macros" do
     testseries4 = @wiki.page("test-series4")
     assert_no_match /Previous/, testseries4.formatted_data
   end
+
+  test "Series macro in subpage" do
+    @wiki.write_page("test-series1", :markdown, "test1", commit_details)
+    @wiki.write_page("test-series2", :markdown, "test2", commit_details)
+    @wiki.write_page("_Footer", :markdown, "<<Series(test)>>", commit_details)
+    test1 = @wiki.page("test-series1")
+    test2 = @wiki.page("test-series2")
+
+    assert_match /Next(.*)test-series2/, test1.footer.formatted_data
+    assert_match /Previous(.*)test-series1/, test2.footer.formatted_data
+  end
+
   
   test "ListArgs with no args" do
     @wiki.write_page("ListArgsMacroPage", :markdown, "<<ListArgs()>>", commit_details)


### PR DESCRIPTION
Fixes #379. I've not used Ruby before so happy to rewrite if there's a better way of doing it or a better place for the change.