### PR TITLE
Only remove valid extensions when generating link display part

### DIFF
--- a/lib/gollum-lib/helpers.rb
+++ b/lib/gollum-lib/helpers.rb
@@ -16,7 +16,7 @@ module Gollum
     # '/opt/local/bin/ruby.ext' -> 'ruby'
     def path_to_link_text(str)
       return nil unless str
-      ::File.basename(str, ::File.extname(str))
+      ::File.basename(str, Page.valid_extension?(str) ? ::File.extname(str) : '')
     end
 
   end

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -197,6 +197,15 @@ context "Markup" do
     assert_match(/href="\/Bilbo%20Baggins.md"/, output)
     assert_match(/\>Bilbo Baggins\</, output)
   end
+  
+  test 'page link with dots' do
+    @wiki.write_page('v1.2', :markdown, 'Test', commit_details)
+    @wiki.write_page('Bilbo Baggins', :markdown, '[[v1.2]]', commit_details)
+    
+    page   = @wiki.page('Bilbo Baggins')
+    output = page.formatted_data
+    assert_equal "<p><a class=\"internal present\" href=\"/v1.2.md\">v1.2</a></p>\n", output
+  end
 
   test "adds nofollow to links on historical pages" do
     sha1 = @wiki.write_page("Sauron", :markdown, "a [[b]] c", commit_details)


### PR DESCRIPTION
See https://github.com/gollum/gollum/issues/1570#issuecomment-642471871

Previously, the display part of a link `[[v1.2]]` would be `v1`, because `.2` was being treated as a file extension, and thus removed. This PR only chops off the extension if it's a valid page extension.