### PR TITLE
Make pandoc compatible with MathJax

### DIFF
--- a/lib/gollum-lib/markups.rb
+++ b/lib/gollum-lib/markups.rb
@@ -58,7 +58,7 @@ module Gollum
     if gem_exists?('pandoc-ruby')
       GitHub::Markup::Markdown::MARKDOWN_GEMS.delete('kramdown')
       GitHub::Markup::Markdown::MARKDOWN_GEMS['pandoc-ruby'] = proc { |content|
-          PandocRuby.convert(content, :from => :markdown, :to => :html, :filter => 'pandoc-citeproc')
+          PandocRuby.convert(content, :from => 'markdown-tex_math_dollars-raw_tex', :to => :html, :filter => 'pandoc-citeproc')
       }
     else
       GitHub::Markup::Markdown::MARKDOWN_GEMS['kramdown'] = proc { |content|


### PR DESCRIPTION
This PR came out of the discussion on https://github.com/gollum/gollum/issues/1589. This change should allow people to install pandoc ruby without seeing any changes to their LaTeX code rendered by MathJax. To do this, we have to tell pandoc-ruby not to treat TeX in any special way, which it does by default.