### PR TITLE
Clear all other markdown gems when using pandoc

### DIFF
--- a/lib/gollum-lib/markups.rb
+++ b/lib/gollum-lib/markups.rb
@@ -56,7 +56,7 @@ end
 module Gollum
   class Markup
     if gem_exists?('pandoc-ruby')
-      GitHub::Markup::Markdown::MARKDOWN_GEMS.delete('kramdown')
+      GitHub::Markup::Markdown::MARKDOWN_GEMS.clear
       GitHub::Markup::Markdown::MARKDOWN_GEMS['pandoc-ruby'] = proc { |content|
           PandocRuby.convert(content, :from => 'markdown-tex_math_dollars-raw_tex', :to => :html, :filter => 'pandoc-citeproc')
       }


### PR DESCRIPTION
See https://github.com/gollum/gollum/issues/1598

Until now, we were removing `kramdown` (which we package with gollum) from the list of github-markup Markdown rendering gems to ensure that our own `pandoc-ruby` setup is used to render Markdown. However, if other markdown gems are installed, those will still be used instead of `pandoc-ruby`. This PR empties the entire list of Markdown gems before defining the pandoc rendering mechanism, thus ensuring that pandoc-ruby is always used when it is installed.

Question @bartkamphorst: is this the behavior we want? I would say yes, but the alternative is to expect the user to uninstall other markdown rendering gems if they want to use pandoc. (This seems very un-userfriendly to me)