### PR TITLE
Don't expand filesystem paths

### DIFF
--- a/lib/gollum-lib/blob_entry.rb
+++ b/lib/gollum-lib/blob_entry.rb
@@ -80,22 +80,21 @@ module Gollum
     def self.normalize_dir(dir)
       return unless dir
 
-      # Return empty string for paths that point to the toplevel
-      # ('.', '/', '..', 'C:/' etc.)
-      return '' if dir =~ %r{\A([a-z]:\/)?[\./]*\z}i
+      dir = dir.dup
 
-      # Normalize the path:
-      # - Add exactly one leading slash
-      # - Remove trailing slashes
-      # - Remove repeated slashes
-      dir.sub(%r{
-        \A
-        ([a-z]:\/)?   # Windows drive letters
-        /*            # leading slashes
-        (?<path>.*?)  # the actual path
-        /*            # trailing slashes
-        \z
-      }xi, '/\k<path>').gsub(%r{//+}, '/')
+      # Remove '.' and '..' path segments
+      dir.gsub!(%r{(\A|/)\.{1,2}(/|\z)}, '/')
+
+      # Remove repeated slashes
+      dir.gsub!(%r{//+}, '/')
+
+      # Remove Windows drive letters, trailing slashes, and keep one leading slash
+      dir.sub!(%r{\A([a-z]:)?/*(.*?)/*\z}i, '/\2')
+
+      # Return empty string for paths that point to the toplevel
+      return '' if dir == '/'
+
+      dir
     end
   end
 end

--- a/lib/gollum-lib/blob_entry.rb
+++ b/lib/gollum-lib/blob_entry.rb
@@ -78,13 +78,24 @@ module Gollum
     # Returns a normalized String directory name, or nil if no directory
     # is given.
     def self.normalize_dir(dir)
-      return '' if dir =~ /^.:\/$/
-      if dir
-        dir = ::File.expand_path(dir, '/')
-        dir = dir[2..-1] if dir =~ /^[a-zA-Z]:\// # expand_path may add d:/ on windows
-        dir = '' if dir == '/'
-      end
-      dir
+      return unless dir
+
+      # Return empty string for paths that point to the toplevel
+      # ('.', '/', '..', 'C:/' etc.)
+      return '' if dir =~ %r{\A([a-z]:\/)?[\./]*\z}i
+
+      # Normalize the path:
+      # - Add exactly one leading slash
+      # - Remove trailing slashes
+      # - Remove repeated slashes
+      dir.sub(%r{
+        \A
+        ([a-z]:\/)?   # Windows drive letters
+        /*            # leading slashes
+        (?<path>.*?)  # the actual path
+        /*            # trailing slashes
+        \z
+      }xi, '/\k<path>').gsub(%r{//+}, '/')
     end
   end
 end

--- a/lib/gollum-lib/file.rb
+++ b/lib/gollum-lib/file.rb
@@ -171,7 +171,7 @@ module Gollum
       return false if @blob.is_symlink && !FS_SUPPORT_SYMLINKS
 
       # This will try to resolve symbolic links, as well
-      pathname = Pathname.new(::File.expand_path(::File.join(@wiki.repo.path, '..', @path)))
+      pathname = Pathname.new(::File.join(@wiki.repo.path, '..', @path))
       if pathname.symlink?
         source   = ::File.readlink(pathname.to_path)
         realpath = ::File.join(::File.dirname(pathname.to_path), source)

--- a/lib/gollum-lib/file.rb
+++ b/lib/gollum-lib/file.rb
@@ -171,7 +171,7 @@ module Gollum
       return false if @blob.is_symlink && !FS_SUPPORT_SYMLINKS
 
       # This will try to resolve symbolic links, as well
-      pathname = Pathname.new(::File.join(@wiki.repo.path, '..', @path))
+      pathname = Pathname.new(::File.join(@wiki.repo.path, '..', BlobEntry.normalize_dir(@path)))
       if pathname.symlink?
         source   = ::File.readlink(pathname.to_path)
         realpath = ::File.join(::File.dirname(pathname.to_path), source)

--- a/test/test_page.rb
+++ b/test/test_page.rb
@@ -167,6 +167,9 @@ context "Page" do
   end
 
   test "normalize_dir" do
+    assert_equal nil, Gollum::BlobEntry.normalize_dir(nil)
+
+    # Toplevel paths
     assert_equal "", Gollum::BlobEntry.normalize_dir("")
     assert_equal "", Gollum::BlobEntry.normalize_dir(".")
     assert_equal "", Gollum::BlobEntry.normalize_dir("..")
@@ -175,20 +178,28 @@ context "Page" do
     assert_equal "", Gollum::BlobEntry.normalize_dir("c:/")
     assert_equal "", Gollum::BlobEntry.normalize_dir("C:/")
 
-    assert_equal nil, Gollum::BlobEntry.normalize_dir(nil)
-    assert_equal "/ ", Gollum::BlobEntry.normalize_dir(" ")
-    assert_equal "/\t", Gollum::BlobEntry.normalize_dir("\t")
-
+    # Normalize slashes
     assert_equal "/foo/bar", Gollum::BlobEntry.normalize_dir("foo/bar")
     assert_equal "/foo/bar", Gollum::BlobEntry.normalize_dir("/foo/bar")
     assert_equal "/foo/bar", Gollum::BlobEntry.normalize_dir("/foo/bar/")
     assert_equal "/foo/bar", Gollum::BlobEntry.normalize_dir("//foo//bar//")
     assert_equal "/foo/bar", Gollum::BlobEntry.normalize_dir("c://foo//bar//")
 
+    # Don't traverse paths
+    assert_equal "/foo/bar", Gollum::BlobEntry.normalize_dir('foo/./bar')
+    assert_equal "/foo/bar", Gollum::BlobEntry.normalize_dir('foo/../bar')
+    assert_equal "/foo/bar", Gollum::BlobEntry.normalize_dir('../foo/../bar/..')
+
+    # Don't expand tildes
     assert_equal "/~/foo", Gollum::BlobEntry.normalize_dir("~/foo")
     assert_equal "/~root/foo", Gollum::BlobEntry.normalize_dir("~root/foo")
     assert_equal "/~!/foo", Gollum::BlobEntry.normalize_dir("~!/foo")
     assert_equal "/foo/~", Gollum::BlobEntry.normalize_dir("foo/~")
+
+    # Special values that are still valid paths
+    assert_equal "/ ", Gollum::BlobEntry.normalize_dir(" ")
+    assert_equal "/\t", Gollum::BlobEntry.normalize_dir("\t")
+    assert_equal "/...", Gollum::BlobEntry.normalize_dir("...")
   end
 
   test 'page has sha id' do

--- a/test/test_page.rb
+++ b/test/test_page.rb
@@ -169,10 +169,26 @@ context "Page" do
   test "normalize_dir" do
     assert_equal "", Gollum::BlobEntry.normalize_dir("")
     assert_equal "", Gollum::BlobEntry.normalize_dir(".")
+    assert_equal "", Gollum::BlobEntry.normalize_dir("..")
     assert_equal "", Gollum::BlobEntry.normalize_dir("/")
+    assert_equal "", Gollum::BlobEntry.normalize_dir("//")
     assert_equal "", Gollum::BlobEntry.normalize_dir("c:/")
-    assert_equal "/foo", Gollum::BlobEntry.normalize_dir("foo")
-    assert_equal "/foo", Gollum::BlobEntry.normalize_dir("/foo")
+    assert_equal "", Gollum::BlobEntry.normalize_dir("C:/")
+
+    assert_equal nil, Gollum::BlobEntry.normalize_dir(nil)
+    assert_equal "/ ", Gollum::BlobEntry.normalize_dir(" ")
+    assert_equal "/\t", Gollum::BlobEntry.normalize_dir("\t")
+
+    assert_equal "/foo/bar", Gollum::BlobEntry.normalize_dir("foo/bar")
+    assert_equal "/foo/bar", Gollum::BlobEntry.normalize_dir("/foo/bar")
+    assert_equal "/foo/bar", Gollum::BlobEntry.normalize_dir("/foo/bar/")
+    assert_equal "/foo/bar", Gollum::BlobEntry.normalize_dir("//foo//bar//")
+    assert_equal "/foo/bar", Gollum::BlobEntry.normalize_dir("c://foo//bar//")
+
+    assert_equal "/~/foo", Gollum::BlobEntry.normalize_dir("~/foo")
+    assert_equal "/~root/foo", Gollum::BlobEntry.normalize_dir("~root/foo")
+    assert_equal "/~!/foo", Gollum::BlobEntry.normalize_dir("~!/foo")
+    assert_equal "/foo/~", Gollum::BlobEntry.normalize_dir("foo/~")
   end
 
   test 'page has sha id' do


### PR DESCRIPTION
Paths starting with a `~` tilde character were getting expanded by the
call to `File.expand_path` in `BlobEntry.normalize_dir`. This can cause
an exception when the tilde is followed by an invalid username, which
makes the whole wiki unusable.

This overrides `BlobEntry.normalize_dir` so it doesn't expand tildes
anymore, and extends the tests a bit.

There's another call to `File.expand_path` in `File.get_disk_reference`
which could be exploited similarly, this one was just removed because it
doesn't seem to be needed.