### PR TITLE
Add post_wiki_initialize hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Note that `base_path` just modifies the links.
 Get the latest version of the given human or canonical page name:
 
 ```ruby
-page = wiki.page('/page name') # Finds pages in the root directory of the wiki that are named 'page name' with a valid extension. 
+page = wiki.page('/page name') # Finds pages in the root directory of the wiki that are named 'page name' with a valid extension.
 # => <Gollum::Page>
 
 page = wiki.page('page name') # For convenience, you can leave out the '/' in front. Paths are assumed to be relative to '/'.
@@ -216,6 +216,21 @@ end
 
 Gollum::Hook.unregister(:post_commit, :hook_id)
 ```
+
+Register or unregister a hook to be called after the wiki is initialized:
+
+```ruby
+Gollum::Hook.register(:post_wiki_initialize, :hook_id) do |wiki|
+  # Your code here
+end
+
+Gollum::Hook.unregister(:post_wiki_initialize, :hook_id)
+```
+
+A combination of both hooks can be used to pull from a remote after
+`:post_wiki_initialize` and push to a remote after `:post_commit` which in
+effect keeps the remote in sync both ways. Keep in mind that it may not be
+possible to resolve all conflicts automatically.
 
 ## WINDOWS FILENAME VALIDATION
 

--- a/lib/gollum-lib/wiki.rb
+++ b/lib/gollum-lib/wiki.rb
@@ -150,6 +150,8 @@ module Gollum
       @filter_chain.delete(:Emoji) unless options.fetch :emoji, false
       @filter_chain.delete(:PandocBib) unless ::Gollum::MarkupRegisterUtils.using_pandoc?
       @filter_chain.delete(:CriticMarkup) unless options.fetch :critic_markup, false
+
+      Hook.execute(:post_wiki_initialize, self)
     end
 
     # Public: check whether the wiki's git repo exists on the filesystem.

--- a/test/test_wiki.rb
+++ b/test/test_wiki.rb
@@ -1,6 +1,21 @@
 # ~*~ encoding: utf-8 ~*~
 require File.expand_path(File.join(File.dirname(__FILE__), "helper"))
 
+context "Wiki initialize" do
+  test "post_wiki_initialize hooks called after initializing" do
+    yielded = nil
+    begin
+      Gollum::Hook.register(:post_wiki_initialize, :hook) do |wiki|
+        yielded = wiki
+      end
+
+      assert_equal Gollum::Wiki.new(testpath("examples/lotr.git")), yielded
+    ensure
+      Gollum::Hook.unregister(:post_wiki_initialize, :hook)
+    end
+  end
+end
+
 context "Wiki" do
   setup do
     @wiki                       = Gollum::Wiki.new(testpath("examples/lotr.git"))


### PR DESCRIPTION
@dometto First things first: I wish you a Happy New Year 2021!

This is a small addition, a second hook called `:post_wiki_initialize`. It complements the existing `:post_commit` hook by offering a way to run code before Gollum renders any kind of page.

I've added a possible use case to the README:

> A combination of both hooks can be used to pull from a remote after
`:post_wiki_initialize` and push from a remote after `:post_commit` which in
effect keeps the remote in sync. Please note: The remote should be read-only
since it may be impossible to resolve conflicts automatically.

My use case is slightly different: I'm running a dockerized GitLab instance and host the git repo for Gollum there. The web server which serves the Gollum wiki uses a clone of this wiki repo. (Nice detail: Since GitLab now features per project access tokens, the clone can be synced without having to store real user credentials on the web server.) The two hooks push and pull as explained above.

Thanks for considering to merge this addition! It is not invasive at all, there's next o zero probability for breaking things.

OT: Coding this on my forks of gollum and gollum-lib, I noticed a version mismatch which is kind of nasty to deal with: Both gems require different versions of `octicons` ( ~>8.5 and ~>11 respectively) which Bundler doesn't like. You might wanna consider upping both to ~>11 and cutting patch releases of both to sync them again.
 
