### PR TITLE
Proof of concept: Rmarkdown support

### DIFF
--- a/lib/gollum-lib/filter/code.rb
+++ b/lib/gollum-lib/filter/code.rb
@@ -3,9 +3,7 @@
 #
 # Render a block of code using the Rouge syntax-highlighter.
 
-R = :nil
 require 'rinruby'
-RInterface = RinRuby.new
 
 class Gollum::Filter::Code < Gollum::Filter
   def extract(data)
@@ -159,9 +157,9 @@ class Gollum::Filter::Code < Gollum::Filter
   end
   
   def render_r(content)
-    RInterface.eval 'require(knitr)'
-    RInterface.assign "content", content
-    RInterface.eval "knitr::render_markdown(strict = TRUE)"
-    RInterface.pull "(knitr::knit2html(text = content, fragment.only = TRUE))"
+    R.eval 'require(knitr)'
+    R.assign "content", content
+    R.eval "knitr::render_markdown(strict = TRUE)"
+    R.pull "(knitr::knit2html(text = content, fragment.only = TRUE))"
   end
 end

--- a/lib/gollum-lib/filter/code.rb
+++ b/lib/gollum-lib/filter/code.rb
@@ -3,6 +3,7 @@
 #
 # Render a block of code using the Rouge syntax-highlighter.
 
+R = :nil
 require 'rinruby'
 
 class Gollum::Filter::Code < Gollum::Filter
@@ -157,9 +158,12 @@ class Gollum::Filter::Code < Gollum::Filter
   end
   
   def render_r(content)
-    R.eval 'require(knitr)'
-    R.assign "content", content
-    R.eval "knitr::render_markdown(strict = TRUE)"
-    R.pull "(knitr::knit2html(text = content, fragment.only = TRUE))"
+    r = RinRuby.new(:interactive => false)
+    r.eval 'require(knitr)'
+    r.assign "content", content
+    r.eval "knitr::render_markdown(strict = TRUE)"
+    result = r.pull "(knitr::knit2html(text = content, fragment.only = TRUE))"
+    r.quit
+    result
   end
 end

--- a/lib/gollum-lib/filter/code.rb
+++ b/lib/gollum-lib/filter/code.rb
@@ -158,12 +158,14 @@ class Gollum::Filter::Code < Gollum::Filter
   end
   
   def render_r(content)
-    r = RinRuby.new(:interactive => false)
+    begin
+    r = RinRuby.new(:interactive => false, :echo => false)
     r.eval 'require(knitr)'
     r.assign "content", content
     r.eval "knitr::render_markdown(strict = TRUE)"
-    result = r.pull "(knitr::knit2html(text = content, fragment.only = TRUE))"
-    r.quit
-    result
+    r.pull "(knitr::knit2html(text = content, fragment.only = TRUE))"
+    ensure
+      r.quit
+    end
   end
 end

--- a/lib/gollum-lib/wiki.rb
+++ b/lib/gollum-lib/wiki.rb
@@ -150,7 +150,6 @@ module Gollum
       @filter_chain.delete(:Emoji) unless options.fetch :emoji, false
       @filter_chain.delete(:PandocBib) unless ::Gollum::MarkupRegisterUtils.using_pandoc?
       @filter_chain.delete(:CriticMarkup) unless options.fetch :critic_markup, false
-
       Hook.execute(:post_wiki_initialize, self)
     end
 


### PR DESCRIPTION
Resolves https://github.com/gollum/gollum/issues/1553

I managed to implement support for RMarkdown relatively painlessly by modifying the code filter. Obviously this is only a proof of concept. The biggest problem is that this implementation relies on the RinRuby gem which seems to be no longer maintained. I can't get the `master` version of that gem to work (the app hangs on startup when I `require 'rinruby'`), but the older released gem [has a bug](https://github.com/clbustos/rinruby/issues/7) (fixed on `master`) which means you can't `Ctrrl-D` to interrupt the R process. :( Nevertheless, if there are different R-for-Ruby implementations, we would only have to modify the `render_r` method in the code filter.

Anyway, the end result on gollum is pretty cool:

<img width="983" alt="Screenshot 2021-02-13 at 20 52 20" src="https://user-images.githubusercontent.com/147111/107862074-83a20200-6e4a-11eb-9e3b-d06e0033b54f.png">

For this source:

```
```{r first_r_chunk}
vec <- c(1, 2, 3)
print(vec)
```

Tset

```{r second_r_chunk, echo = FALSE}
vec2 <- c(10, 20, 30)
vec3 <- vec * vec2
print(vec3)     
```

Test

```{r echo = FALSE}
library(ggplot2)
data(mpg, package="ggplot2")

mpg_select <- mpg[mpg$manufacturer %in% c("audi", "ford", "honda", "hyundai"), ]

# Scatterplot
theme_set(theme_bw())  # pre-set the bw theme.
g <- ggplot(mpg_select, aes(displ, cty)) + 
  labs(subtitle="mpg: Displacement vs City Mileage",
       title="Bubble chart")

g + geom_jitter(aes(col=manufacturer, size=hwy)) + 
  geom_smooth(aes(col=manufacturer), method="lm", se=F)
```% 
```
