### PR TITLE
sanitize macros

### DIFF
--- a/lib/gollum-lib/filter/macro.rb
+++ b/lib/gollum-lib/filter/macro.rb
@@ -55,6 +55,6 @@ class Gollum::Filter::Macro < Gollum::Filter
       end
     end
 
-    data
+    sanitize(data)
   end
 end

--- a/lib/gollum-lib/macro/all_pages.rb
+++ b/lib/gollum-lib/macro/all_pages.rb
@@ -3,7 +3,7 @@ module Gollum
     class AllPages < Gollum::Macro
       def render
         if @wiki.pages.size > 0
-          '<ul id="pages">' + @wiki.pages.map { |p| "<li>#{p.name}</li>" }.join + '</ul>'
+          '<ul id="pages">' + @wiki.pages.map { |p| "<li>#{CGI::escapeHTML(p.name)}</li>" }.join + '</ul>'
         end
       end
     end

--- a/lib/gollum-lib/macro/audio.rb
+++ b/lib/gollum-lib/macro/audio.rb
@@ -2,7 +2,7 @@ module Gollum
   class Macro
     class Audio < Gollum::Macro
       def render (fname)
-        "<audio width=\"100%\" height=\"100%\" src=\"#{fname}\" controls=\"\"> HTML5 audio is not supported on this Browser.</audio>"
+        "<audio width=\"100%\" height=\"100%\" src=\"#{CGI::escapeHTML(fname)}\" controls=\"\"> HTML5 audio is not supported on this Browser.</audio>"
       end
     end
   end

--- a/lib/gollum-lib/macro/global_toc.rb
+++ b/lib/gollum-lib/macro/global_toc.rb
@@ -4,9 +4,9 @@ module Gollum
       def render(title = "Global Table of Contents")
         if @wiki.pages.size > 0
           prepath = @wiki.base_path.sub(/\/$/, '')
-          result  = '<ul>' + @wiki.pages.map { |p| "<li><a href=\"#{prepath}/#{p.escaped_url_path}\">#{p.url_path}</a></li>" }.join + '</ul>'
+          result  = '<ul>' + @wiki.pages.map { |p| "<li><a href=\"#{CGI::escapeHTML(prepath + "/" + p.escaped_url_path)}\">#{CGI::escapeHTML(p.url_path)}</a></li>" }.join + '</ul>'
         end
-        "<div class=\"toc\"><div class=\"toc-title\">#{title}</div>#{result}</div>"
+        "<div class=\"toc\"><div class=\"toc-title\">#{CGI::escapeHTML(title)}</div>#{result}</div>"
       end
     end
   end

--- a/lib/gollum-lib/macro/navigation.rb
+++ b/lib/gollum-lib/macro/navigation.rb
@@ -9,12 +9,12 @@ module Gollum
           list_items = pages.map do |page|
             if toc_root_path == '.' || page.url_path =~ /^#{toc_root_path}\//
               path_display = (full_path || toc_root_path == '.') ? page.url_path  : page.url_path.sub(/^#{toc_root_path}\//,"").sub(/^\//,'')
-              "<li><a href=\"#{prepath}/#{page.escaped_url_path}\">#{path_display}</a></li>"
+              "<li><a href=\"#{CGI::escapeHTML(prepath + "/" + page.escaped_url_path)}\">#{CGI::escapeHTML(path_display)}</a></li>"
             end
           end
           result = "<ul>#{list_items.join}</ul>"
         end
-        "<div class=\"toc\"><div class=\"toc-title\">#{title}</div>#{result}</div>"
+        "<div class=\"toc\"><div class=\"toc-title\">#{CGI::escapeHTML(title)}</div>#{result}</div>"
       end
 
     end

--- a/lib/gollum-lib/macro/note.rb
+++ b/lib/gollum-lib/macro/note.rb
@@ -12,7 +12,7 @@ module Gollum
           icon.options[:class] << ' mr-2'
           icon = icon.to_svg
         end
-        "<div class='flash'>#{icon}#{notice}</div>"
+        "<div class='flash'>#{icon}#{CGI::escapeHTML(notice)}</div>"
       end
     end
   end

--- a/lib/gollum-lib/macro/series.rb
+++ b/lib/gollum-lib/macro/series.rb
@@ -8,8 +8,8 @@ module Gollum
       end
 
       def render_links(previous_page, next_page)
-      	result = "Previous: <a href=\"#{::File.join(@wiki.base_path,previous_page.escaped_url_path)}\">#{previous_page.name}</a>" if previous_page
-      	result = "#{result}#{result ? ' | ' : ''}Next: <a href=\"#{::File.join(@wiki.base_path,next_page.escaped_url_path)}\">#{next_page.name}</a>" if next_page
+      	result = "Previous: <a href=\"#{CGI::escapeHTML(::File.join(@wiki.base_path,previous_page.escaped_url_path))}\">#{CGI::escapeHTML(previous_page.name)}</a>" if previous_page
+      	result = "#{result}#{result ? ' | ' : ''}Next: <a href=\"#{CGI::escapeHTML(::File.join(@wiki.base_path,next_page.escaped_url_path))}\">#{CGI::escapeHTML(next_page.name)}</a>" if next_page
       	wrap_result(result)
       end
 
@@ -32,14 +32,14 @@ module Gollum
 
     class SeriesStart < Gollum::Macro::Series
       def render_links(previous_page, next_page)
-        result = "Next: <a href=\"#{::File.join(@wiki.base_path,next_page.escaped_url_path)}\">#{next_page.name}</a>" if next_page
+        result = "Next: <a href=\"#{CGI::escapeHTML(::File.join(@wiki.base_path,next_page.escaped_url_path))}\">#{CGI::escapeHTML(next_page.name)}</a>" if next_page
         wrap_result(result)
       end
     end
 
     class SeriesEnd < Gollum::Macro::Series
       def render_links(previous_page, next_page)
-        result = "Previous: <a href=\"#{::File.join(@wiki.base_path,previous_page.escaped_url_path)}\">#{previous_page.name}</a>" if previous_page
+        result = "Previous: <a href=\"#{CGI::escapeHTML(::File.join(@wiki.base_path,previous_page.escaped_url_path))}\">#{CGI::escapeHTML(previous_page.name)}</a>" if previous_page
         wrap_result(result)
       end
     end

--- a/lib/gollum-lib/macro/video.rb
+++ b/lib/gollum-lib/macro/video.rb
@@ -2,7 +2,7 @@ module Gollum
   class Macro
     class Video < Gollum::Macro
       def render (fname)
-        "<video width=\"100%\" height=\"100%\" src=\"#{fname}\" controls=\"\"> HTML5 video is not supported on this Browser.</video>"
+        "<video width=\"100%\" height=\"100%\" src=\"#{CGI::escapeHTML(fname)}\" controls=\"\"> HTML5 video is not supported on this Browser.</video>"
       end
     end
   end

--- a/lib/gollum-lib/macro/warn.rb
+++ b/lib/gollum-lib/macro/warn.rb
@@ -4,7 +4,7 @@ module Gollum
       def render(warning)
         icon = Octicons::Octicon.new('alert', {width: 24, height: 24})
         icon.options[:class] << ' mr-2'
-        "<div class='flash flash-warn'>#{icon.to_svg}#{warning}</div>"
+        "<div class='flash flash-warn'>#{icon.to_svg}#{CGI::escapeHTML(warning)}</div>"
       end
     end
   end

--- a/test/test_macros.rb
+++ b/test/test_macros.rb
@@ -41,13 +41,13 @@ context "Macros" do
 
   test "GlobalTOC macro displays global table of contents" do
     @wiki.write_page("GlobalTOCMacroPage", :markdown, "<<GlobalTOC(Pages in this Wiki)>>", commit_details)
-    assert_match /<div class="toc">(.*)Pages in this Wiki(.*)<li><a href="\/GlobalTOCMacroPage.md">GlobalTOCMacroPage.md/, @wiki.pages[0].formatted_data
+    assert_match /<div class="toc">(.*)Pages in this Wiki(.*)<li><a href="\/GlobalTOCMacroPage.md" rel="nofollow">GlobalTOCMacroPage.md/, @wiki.pages[0].formatted_data
   end
 
   test "Navigation macro displays table of contents for subpath" do
     @wiki.write_page("NavigationMacroPage", :markdown, "<<Navigation()>>", commit_details)
     @wiki.write_page("ZZZZ/A", :markdown, "content", commit_details)
-    assert_match /<div class="toc"><div class="toc-title">Navigate this directory<\/div><ul><li><a href="\/NavigationMacroPage.md">NavigationMacroPage.md<\/a><\/li><li><a href="\/ZZZZ\/A\.md">ZZZZ\/A\.md<\/a><\/li><\/ul><\/div>/, @wiki.pages[0].formatted_data
+    assert_match /<div class="toc"><div class="toc-title">Navigate this directory<\/div><ul><li><a href="\/NavigationMacroPage.md" rel="nofollow">NavigationMacroPage.md<\/a><\/li><li><a href="\/ZZZZ\/A\.md" rel="nofollow">ZZZZ\/A\.md<\/a><\/li><\/ul><\/div>/, @wiki.pages[0].formatted_data
   end
 
   test "Series macro displays series links with and without series prefix" do
@@ -148,13 +148,13 @@ context "Macros" do
   test "Video macro given a name of a file displays an html5 video tag" do
     file = "/Uploads/foo.mp4"
     @wiki.write_page("VideoTagTest", :markdown, "<<Video(#{file})>>", commit_details)
-    assert_match /<video (.*) (.*) src="#{file}" (.*)> (.*)<\/video>/, @wiki.pages[0].formatted_data
+    assert_match /<video (.*) (.*) src="#{file}"(.*)> (.*)<\/video>/, @wiki.pages[0].formatted_data
   end 
 
   test "Audio macro given a name of a file displays an audio tag" do
     file = "/Uploads/foo.mp3"
     @wiki.write_page("AudioTagTest", :markdown, "<<Audio(#{file})>>", commit_details)
-    assert_match /<audio (.*) (.*) src="#{file}" (.*)> (.*)<\/audio>/, @wiki.pages[0].formatted_data
+    assert_match /<audio (.*) (.*) src="#{file}"(.*)> (.*)<\/audio>/, @wiki.pages[0].formatted_data
   end
 
   test "Octicon macro given a symbol and dimensions displays octicon" do

--- a/test/test_macros.rb
+++ b/test/test_macros.rb
@@ -179,4 +179,8 @@ context "Macros" do
     assert_match /<div class=\"flash flash-error\"><svg.*class=\"octicon octicon-zap mr-2\".*Macro Error for Octicon: Couldn't find octicon symbol for "foobar".*/, @wiki.pages[0].formatted_data
   end
 
+  test "escape HTML special characters" do
+    @wiki.write_page("AudioXSSTest", :markdown, '<<Audio(a"></audio><input>)>>', commit_details)
+    assert_not_match /<input/, @wiki.pages[0].formatted_data
+  end
 end

--- a/test/test_macros.rb
+++ b/test/test_macros.rb
@@ -148,13 +148,13 @@ context "Macros" do
   test "Video macro given a name of a file displays an html5 video tag" do
     file = "/Uploads/foo.mp4"
     @wiki.write_page("VideoTagTest", :markdown, "<<Video(#{file})>>", commit_details)
-    assert_match /<video (.*) (.*) src="#{file}"(.*)> (.*)<\/video>/, @wiki.pages[0].formatted_data
+    assert_match /<video (.*) src="#{file}"(.*)> (.*)<\/video>/, @wiki.pages[0].formatted_data
   end 
 
   test "Audio macro given a name of a file displays an audio tag" do
     file = "/Uploads/foo.mp3"
     @wiki.write_page("AudioTagTest", :markdown, "<<Audio(#{file})>>", commit_details)
-    assert_match /<audio (.*) (.*) src="#{file}"(.*)> (.*)<\/audio>/, @wiki.pages[0].formatted_data
+    assert_match /<audio (.*) src="#{file}"(.*)> (.*)<\/audio>/, @wiki.pages[0].formatted_data
   end
 
   test "Octicon macro given a symbol and dimensions displays octicon" do


### PR DESCRIPTION
@dometto This is a PR which fixes the XSS vulnerability I reported to you by email just now.

I think using sanitize(data) as you said is a good idea because custom macros can also be escaped, but CGI::escapeHTML is also necessary to avoid outputting safe but broken HTML, so I used both.
