### PR TITLE
Remove escape_html calls

### DIFF
--- a/lib/gollum-lib/macro/global_toc.rb
+++ b/lib/gollum-lib/macro/global_toc.rb
@@ -6,7 +6,7 @@ module Gollum
           prepath = @wiki.base_path.sub(/\/$/, '')
           result  = '<ul>' + @wiki.pages.map { |p| "<li><a href=\"#{CGI::escapeHTML(prepath + "/" + p.escaped_url_path)}\">#{CGI::escapeHTML(p.url_path)}</a></li>" }.join + '</ul>'
         end
-        "<div class=\"toc\"><div class=\"toc-title\">#{CGI::escapeHTML(title)}</div>#{result}</div>"
+        "<div class=\"toc\"><div class=\"toc-title\">#{title}</div>#{result}</div>"
       end
     end
   end

--- a/lib/gollum-lib/macro/navigation.rb
+++ b/lib/gollum-lib/macro/navigation.rb
@@ -14,7 +14,7 @@ module Gollum
           end
           result = "<ul>#{list_items.join}</ul>"
         end
-        "<div class=\"toc\"><div class=\"toc-title\">#{CGI::escapeHTML(title)}</div>#{result}</div>"
+        "<div class=\"toc\"><div class=\"toc-title\">#{title}</div>#{result}</div>"
       end
 
     end

--- a/lib/gollum-lib/macro/note.rb
+++ b/lib/gollum-lib/macro/note.rb
@@ -12,7 +12,7 @@ module Gollum
           icon.options[:class] << ' mr-2'
           icon = icon.to_svg
         end
-        "<div class='flash'>#{icon}#{CGI::escapeHTML(notice)}</div>"
+        "<div class='flash'>#{icon}#{notice}</div>"
       end
     end
   end

--- a/lib/gollum-lib/macro/warn.rb
+++ b/lib/gollum-lib/macro/warn.rb
@@ -4,7 +4,7 @@ module Gollum
       def render(warning)
         icon = Octicons::Octicon.new('alert', {width: 24, height: 24})
         icon.options[:class] << ' mr-2'
-        "<div class='flash flash-warn'>#{icon.to_svg}#{CGI::escapeHTML(warning)}</div>"
+        "<div class='flash flash-warn'>#{icon.to_svg}#{warning}</div>"
       end
     end
   end

--- a/test/test_macros.rb
+++ b/test/test_macros.rb
@@ -179,8 +179,20 @@ context "Macros" do
     assert_match /<div class=\"flash flash-error\"><svg.*class=\"octicon octicon-zap mr-2\".*Macro Error for Octicon: Couldn't find octicon symbol for "foobar".*/, @wiki.pages[0].formatted_data
   end
 
-  test "escape HTML special characters" do
+  test "Audio macro escapes HTML" do
     @wiki.write_page("AudioXSSTest", :markdown, '<<Audio(a"></audio><input>)>>', commit_details)
     assert_not_match /<input/, @wiki.pages[0].formatted_data
+  end
+
+  test "Note macro renders HTML code" do
+    @wiki.write_page("HTMLNoteMacroPage", :markdown, '<<Note("<span>test</span>")>>', commit_details)
+    assert_match /<div class=\"flash\"><svg.*class=\"octicon octicon-info mr-2\".*<span>test<\/span>.*/, @wiki.pages[0].formatted_data
+  end
+
+  test "Series macro escapes page names" do
+    @wiki.write_page("test-1", :markdown, "test1", commit_details)
+    @wiki.write_page("test-2<span>", :markdown, "test2", commit_details)
+    @wiki.write_page("_Footer", :markdown, "<<Series(test)>>", commit_details)
+    assert_match /Next(.*)test-2&lt;span&gt;/, @wiki.page("test-1").footer.formatted_data
   end
 end


### PR DESCRIPTION
This PR fixes https://github.com/gollum/gollum/issues/1746. I removed the `escape_html`s applied to `title`, `notice`, and `warning`. I also added tests for them.
