### PR TITLE
Allow escaping quotations in quoted macro arguments.

### DIFF
--- a/lib/gollum-lib/filter/macro.rb
+++ b/lib/gollum-lib/filter/macro.rb
@@ -26,7 +26,7 @@ class Gollum::Filter::Macro < Gollum::Filter
         if argument =~ /^([a-z0-9_]+)="(.*?)"/
       		opts[Regexp.last_match[1]] = Regexp.last_match[2]
 			  elsif argument =~ /^"(.*)"$/
-          args << Regexp.last_match[1].gsub("\\\"", "\"")
+				  args << Regexp.last_match[1].gsub("\\\"", "\"")
 			  else
 				  args << argument
         end

--- a/lib/gollum-lib/filter/macro.rb
+++ b/lib/gollum-lib/filter/macro.rb
@@ -4,7 +4,7 @@ require 'octicons'
 # Replace specified tokens with dynamically generated content.
 class Gollum::Filter::Macro < Gollum::Filter
   def extract(data)
-    quoted_arg   = %r{".*?"}
+    quoted_arg   = %r{".*?(?<!\\)"}
     unquoted_arg = %r{[^,)]+}
     named_arg    = %r{[a-z0-9_]+=".*?"}
     
@@ -26,7 +26,7 @@ class Gollum::Filter::Macro < Gollum::Filter
         if argument =~ /^([a-z0-9_]+)="(.*?)"/
       		opts[Regexp.last_match[1]] = Regexp.last_match[2]
 			  elsif argument =~ /^"(.*)"$/
-      		args << Regexp.last_match[1]
+          args << Regexp.last_match[1].gsub("\\\"", "\"")
 			  else
 				  args << argument
         end

--- a/lib/gollum-lib/filter/macro.rb
+++ b/lib/gollum-lib/filter/macro.rb
@@ -4,7 +4,7 @@ require 'octicons'
 # Replace specified tokens with dynamically generated content.
 class Gollum::Filter::Macro < Gollum::Filter
   def extract(data)
-    quoted_arg   = %r{".*?(?<!\\)"}
+    quoted_arg   = %r{".*?(?<!\\)"} # use a negative lookbehind to not terminate on a " preceeded by \
     unquoted_arg = %r{[^,)]+}
     named_arg    = %r{[a-z0-9_]+=".*?"}
     

--- a/test/test_macros.rb
+++ b/test/test_macros.rb
@@ -127,6 +127,11 @@ context "Macros" do
     assert_match(/@\(bar\)@/, @wiki.pages[0].formatted_data)
   end
 
+  test "ListArgs with escaped quotation mark in quoted args" do
+    @wiki.write_page("ListArgsMacroPage", :markdown, '<<ListArgs("Goodbye \"cruel\" world")>>', commit_details)
+    assert_match(/@Goodbye "cruel" world@/, @wiki.pages[0].formatted_data)
+  end
+
   test "ListArgs with a mix or arg styles" do
     @wiki.write_page("ListArgsMacroPage", :markdown, '<<ListArgs("foo, bar, and baz", wombat, funny things)>>', commit_details)
     assert_match(/@foo, bar, and baz@/, @wiki.pages[0].formatted_data)


### PR DESCRIPTION
This allows using quotation marks inside quoted macro arguments.

Example:

```
<<MyMacro("This is only \"one\" quoted argument.")>>
```
