### PR TITLE
Improve code filter performance

### DIFF
--- a/lib/gollum-lib/filter.rb
+++ b/lib/gollum-lib/filter.rb
@@ -58,9 +58,10 @@ module Gollum
       @map    = {}
       @open_pattern = "%#{self.class.to_s.split('::').last}%"
       @close_pattern = "=#{self.class.to_s.split('::').last}="
+      @hash_pattern = %r{#{open_pattern}[a-f0-9]{40}#{close_pattern}}
     end
 
-    attr_reader :open_pattern, :close_pattern
+    attr_reader :open_pattern, :close_pattern, :hash_pattern
 
     def extract(data)
       raise RuntimeError,


### PR DESCRIPTION
I thought I saw an opportunity for improving the performance of the code filter. Instead of calling `data.gsub!` for every `id` in `@map`, we can call `data.gsub!` only once, and have it match all substitution patterns.

This refactor passes the tests, but they don't run noticeably faster. @bartkamphorst can you remind me how to do a quick performance test?