### PR TITLE
Implement language handlers in Code Filter

### DIFF
--- a/lib/gollum-lib/filter/code.rb
+++ b/lib/gollum-lib/filter/code.rb
@@ -8,11 +8,15 @@
 
 class Gollum::Filter::Code < Gollum::Filter
   
-  @@language_handlers = {
-    /mermaid/ => Proc.new { |lang, code| "<div class=\"mermaid\">\n#{code}\n</div>" },
-    /{.*}/ => Proc.new { |lang, code| "<pre class=\"knitr\"><code class=\"#{lang}\">\n#{code}\n</code></pre>"}
-  }
-
+  # The @language_handlers Hash can be filled with Regep keys and corresponding Proc values. The Procs will be executed to handle a codeblock whose language definition matches the key.
+  # See the Code Filter tests for an example
+  # Use the Gollum::Filter::Code.language_handlers method to access and modify this class instance variable
+  @language_handlers = {}
+    
+  class << self
+    attr_accessor :language_handlers
+  end
+  
   def extract(data)
     case @markup.format
     when :asciidoc
@@ -75,7 +79,7 @@ class Gollum::Filter::Code < Gollum::Filter
     wrapped_blocks = []
     blocks.each do |lang, code|
       
-      if (_pattern, proc = @@language_handlers.find { |pattern, _v| lang =~ pattern }) then
+      if (_pattern, proc = self.class.language_handlers.find { |pattern, _v| lang =~ pattern }) then
         wrapped_blocks << proc.call(CGI.escape_html(lang), CGI.escape_html(code))
         next
       end

--- a/test/filter/test_code.rb
+++ b/test/filter/test_code.rb
@@ -10,6 +10,18 @@ context "Gollum::Filter::Code" do
     @filter.process(@filter.extract(content))
   end
   
+end
+
+context "Gollum::Filter::Code with language handler" do
+  setup do
+    @filter = Gollum::Filter::Code.new(Gollum::Markup.new(mock_page))
+    Gollum::Filter::Code.language_handlers[/mermaid/] = Proc.new { |lang, code| "<div class=\"mermaid\">\n#{code}\n</div>" }
+  end
+
+  def filter(content)
+    @filter.process(@filter.extract(content))
+  end
+  
   test 'mermaid language handler' do
     markup = <<~EOF
     # Some markup
@@ -29,5 +41,8 @@ context "Gollum::Filter::Code" do
     assert filter(markup), result
   end
   
+  teardown do
+    Gollum::Filter::Code.language_handlers = {}
+  end
   
 end

--- a/test/filter/test_code.rb
+++ b/test/filter/test_code.rb
@@ -1,0 +1,33 @@
+path = File.join(File.dirname(__FILE__), "..", "helper")
+require File.expand_path(path)
+
+context "Gollum::Filter::Code" do
+  setup do
+    @filter = Gollum::Filter::Code.new(Gollum::Markup.new(mock_page))
+  end
+
+  def filter(content)
+    @filter.process(@filter.extract(content))
+  end
+  
+  test 'mermaid language handler' do
+    markup = <<~EOF
+    # Some markup
+    
+    ```mermaid
+    sequenceDiagram
+      Alice->>John: Hello John, how are you?
+      John-->>Alice: Great!
+      Alice-)John: See you later!
+    ```
+    
+    Foo
+    EOF
+    
+    result = "# Some markup\n\n<div class=\"mermaid\">\nsequenceDiagram\n  Alice-&gt;&gt;John: Hello John, how are you?\n  John--&gt;&gt;Alice: Great!\n  Alice-)John: See you later!\n</div>\n\nFoo\n"
+    
+    assert filter(markup), result
+  end
+  
+  
+end


### PR DESCRIPTION
This PR implements customizable behavior for handling code blocks in specific languages in the `Code` filter. Usually, we want to simply highlight a code block. But in some cases, we (or the user) might want to skip highlighting and instead process a code block in a different way. Two possible use cases:

* Implementing support for [Mermaid](https://github.com/gollum/gollum/issues/1473)
* Implementing support for [RMarkdown](https://github.com/gollum/gollum/issues/1553)

In both cases, we want to preserve the code in the block so that it can be processed in a different way later.

With the current implementation, it's trivial to define custom behavior for new languages: just add a pattern and a `Proc` object to `Gollum::Filter::Code`'s `@@language_handlers` hash.

We could also choose to keep that hash empty in `gollum-lib`, and instead define the handlers in `gollum` (if we don't want to have more frontend-specific HTML in `gollum-lib`). To illustrate the functionality, I've just defined two handlers for Mermaid and RMarkdown here.

Note: the idea behind this is that we don't really want to have a separate filter for Mermaid and RMarkdown (and whatever else), since that would require going through the entire document to find/replace codeblocks in multiple filters, which would be inefficient.