### PR TITLE
much safer default, don't send sensitive information onto the internet

### DIFF
--- a/lib/gollum-lib/filter/plantuml.rb
+++ b/lib/gollum-lib/filter/plantuml.rb
@@ -37,7 +37,7 @@ require 'zlib'
 #
 class Gollum::Filter::PlantUML < Gollum::Filter
 
-  DEFAULT_URL = "http://www.plantuml.com/plantuml/png"
+  DEFAULT_URL = "http://localhost:8080/plantuml/png"
 
   # Configuration class used to change the behaviour of the PlatnUML filter.
   #


### PR DESCRIPTION
The changeset https://github.com/gollum/gollum-lib/commit/a47ac0e7d91d82a6458c9f0828781a5971603a85 changed the default for plantuml to be a public internet site. This to me is a serious issue, because if one forgets to set a different configuration, then all potentially sensitive diagram will be flooded into the public internet.

Given that you can easily configure to use the public internet site with just a simply supplied config file such as:

```ruby
Gollum::Filter::PlantUML.configure do |config|
    config.url = "http://www.plantuml.com/plantuml/png"
end
```

I would **_highly_** recommend that this PR be accepted, and that configuration be displayed on https://github.com/gollum/gollum/wiki/Custom-PlantUML-Server#configuring-a-plantuml-server