### PR TITLE
allow for the extended plantuml types

### DIFF
--- a/lib/gollum-lib/filter/plantuml.rb
+++ b/lib/gollum-lib/filter/plantuml.rb
@@ -69,7 +69,7 @@ class Gollum::Filter::PlantUML < Gollum::Filter
   # Extract all sequence diagram blocks into the map and replace with
   # placeholders.
   def extract(data)
-    data.gsub(/(@startuml\r?\n.+?\r?\n@enduml\r?$)/m) do
+    data.gsub(/(@start(uml|json|yaml|salt|mindmap|wbs|math|latex)\r?\n.+?\r?\n@end\2\r?$)/m) do
       id       = "#{open_pattern}#{Digest::SHA1.hexdigest($1)}#{close_pattern}"
       @map[id] = { :code => $1 }
       id


### PR DESCRIPTION
https://plantuml.com/ have created new tokens to denote newer diagrams which are not currently supported by gollum (which is just looking for `@startuml`/`@enduml`).

This extends the set of tags to the complete (?) set that I found on https://plantuml.com/

`@startjson`/`@endjson` = https://plantuml.com/json
`@startyaml`/`@endyaml` = https://plantuml.com/yaml
`@startsalt`/`@endsalt` = https://plantuml.com/salt
`@startmindmap`/`@endmindmap` = https://plantuml.com/mindmap-diagram
`@startwbs`/`@endwbs` = https://plantuml.com/wbs-diagram
`@startmath`/`@endmath` & `@startlatex`/`@endlatex` = https://plantuml.com/ascii-math

