### PR TITLE
Add Ruby 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.6, 2.7, 3.0]
+        ruby: ['2.6', '2.7', '3.0', '3.1']
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2


### PR DESCRIPTION
Same change as in gollum/gollum#1812. 😄 

---

This PR adds Ruby 3.1 to the CI matrix.

Using 3.0 without quotes, ruby/setup-ruby will use 3.1 instead of 3.0.
To avoid similar parsing issues, all version numbers are enclosed in quotes.