### PR TITLE
Fix deprecation warnings

### DIFF
--- a/lib/gollum-lib/filter/toc.rb
+++ b/lib/gollum-lib/filter/toc.rb
@@ -125,7 +125,7 @@ class Gollum::Filter::TOC < Gollum::Filter
   # Creates an anchor element with the given name and adds it before
   # the given header element.
   def add_anchor_to_header(header, name)
-    a = Nokogiri::XML::Node.new('a', @doc)
+    a = Nokogiri::XML::Node.new('a', @doc.document)
     a['class'] = 'anchor'
     a['id'] = name
     a['href'] = "##{name}"
@@ -143,9 +143,9 @@ class Gollum::Filter::TOC < Gollum::Filter
 
     if @tail_level < level
       while @tail_level < level
-        list = Nokogiri::XML::Node.new('ul', @doc)
+        list = Nokogiri::XML::Node.new('ul', @doc.document)
         @tail.add_child(list)
-        @tail = list.add_child(Nokogiri::XML::Node.new('li', @doc))
+        @tail = list.add_child(Nokogiri::XML::Node.new('li', @doc.document))
         @tail_level += 1
       end
     else
@@ -153,7 +153,7 @@ class Gollum::Filter::TOC < Gollum::Filter
         @tail = @tail.parent.parent
         @tail_level -= 1
       end
-      @tail = @tail.parent.add_child(Nokogiri::XML::Node.new('li', @doc))
+      @tail = @tail.parent.add_child(Nokogiri::XML::Node.new('li', @doc.document))
     end
 
     # % -> %25 so anchors work on Firefox. See issue #475

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -6,7 +6,7 @@ require 'fileutils'
 # external
 require 'rubygems'
 require 'shoulda'
-require 'mocha/setup'
+require 'mocha/test_unit'
 require 'minitest/reporters'
 require 'twitter_cldr'
 require 'tempfile'


### PR DESCRIPTION
This PR suppresses deprecation warnings at test running.
It includes the following:
- Pass a Document as the second parameter to `Nokogiri::XML::Node.new`.
This will suppress the following warning:
  ```
  warning: Passing a Node as the second parameter to Node.new is deprecated. Please pass a Document instead, or prefer an 
  alternative constructor like Node#add_child. This will become an error in a future release of Nokogiri.
  ```
  Please see the following for more details:
  https://github.com/sparklemotion/nokogiri/issues/975
- Require 'mocha/test_unit' instead of 'mocha/setup'
This will suppress the following deprecation warning:
  ```
  Mocha deprecation warning at /home/runner/work/gollum-lib/gollum-lib/test/helper.rb:9:in `require': Require 'mocha/test_unit', 'mocha/minitest' or 'mocha/api' instead of 'mocha/setup'.
  ```