### PR TITLE
Remove gemspec fields that should not be set

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,5 @@
 require 'rubygems'
 require 'rake'
-require 'date'
 
 #############################################################################
 #
@@ -38,24 +37,16 @@ def bump_version
   new_version
 end
 
-def date
-  Date.today.to_s
-end
-
-def rubyforge_project
-  name
-end
-
 def gemspec_file
   "gemspec.rb"
 end
 
 def gemspecs
-   ["#{name}.gemspec", "#{name}_java.gemspec"]
+  ["#{name}.gemspec", "#{name}_java.gemspec"]
 end
 
 def gem_files
- ["#{name}-#{version}.gem", "#{name}-#{version}-java.gem"]
+  ["#{name}-#{version}.gem", "#{name}-#{version}-java.gem"]
 end
 
 def replace_header(head, header_name)
@@ -152,11 +143,8 @@ task :gemspec => :validate do
   spec = File.read(gemspec_file)
   head, _manifest, tail = spec.split("  # = MANIFEST =\n")
 
-  # replace name version and date
+  # replace name
   replace_header(head, :name)
-  replace_header(head, :date)
-  #comment this out if your rubyforge_project has a different name
-  replace_header(head, :rubyforge_project)
 
   # determine file list from git ls-files
   files = `git ls-files`.

--- a/gemspec.rb
+++ b/gemspec.rb
@@ -1,16 +1,11 @@
 def specification(version, default_adapter, platform = nil)
   Proc.new do |s|
-    s.specification_version = 2 if s.respond_to? :specification_version=
     s.required_rubygems_version = Gem::Requirement.new('>= 0') if s.respond_to? :required_rubygems_version=
-    s.rubygems_version = '0.0.1'
     s.required_ruby_version = '>= 2.4'
 
     s.name              = 'gollum-lib'
     s.version           = version
     s.platform          = platform if platform
-    s.date              = '2021-09-06'
-    s.date              = '2017-04-13'
-    s.rubyforge_project = 'gollum-lib'
     s.license           = 'MIT'
 
     s.summary     = 'A simple, Git-powered wiki.'


### PR DESCRIPTION
Similar changes as in gollum/gollum#1811.

RubyGems says not to set the value to [`date`](https://github.com/rubygems/rubygems/blob/fe96fb6e2ac5a8b6df5e852470d11fa854301eca/lib/rubygems/specification.rb#L1677-L1682), [`specification_version`](https://github.com/rubygems/rubygems/blob/fe96fb6e2ac5a8b6df5e852470d11fa854301eca/lib/rubygems/specification.rb#L750-L755) and [`rubygems_version`](https://github.com/rubygems/rubygems/blob/fe96fb6e2ac5a8b6df5e852470d11fa854301eca/lib/rubygems/specification.rb#L536-L541).
Also, `rubyforge_project` is deprecated.

This PR removes those fields from gemspec.
And does the following:
- Fix gemspec task not to set date and rubyforge_project field.

