### PR TITLE
Update octicons

### DIFF
--- a/gemspec.rb
+++ b/gemspec.rb
@@ -26,7 +26,7 @@ def specification(version, default_adapter, platform = nil)
     s.add_dependency 'loofah', '~> 2.3'
     s.add_dependency 'github-markup', '~> 4.0'
     s.add_dependency 'gemojione', '~> 4.1'
-    s.add_dependency 'octicons', '~> 12.0'
+    s.add_dependency 'octicons', '~> 17.0'
     s.add_dependency 'twitter-text', '1.14.7'
 
     s.add_development_dependency 'org-ruby', '~> 0.9.9'


### PR DESCRIPTION
Looked at the breaking changes for `octicons` since v.12:

```
        THIS IS A BREAKING CHANGE and will require re-linking all the file-directory icon references to file-directory-fill
	•	Rename 16px select-single icon to single-select #665
	•	Rename duplicate icon to copy #643
	•	Rename clippy icon to paste #643
	•	Remove octoface #611
	•	Rename git-fork-24 to repo-forked-24 #593
	•	Remove 24px insights icon #574
	•	Remove 24px copy icon #586
```

None should affect gollum-lib.