### PR TITLE
Implement default branch detection, move away from master as default.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,9 @@
 source 'https://rubygems.org'
 gemspec :name => 'gollum-lib'
 gem 'irb'
-gem 'gollum-rugged_adapter', :git => 'https://github.com/gollum/rugged_adapter/', :branch => 'find_branches'
+
+if RUBY_PLATFORM == 'java'
+  gem 'gollum-rjgit_adapter', git: 'https://github.com/dometto/gollum-lib_rjgit_adapter/', branch: 'find_branch'
+else
+  gem 'gollum-rugged_adapter', git: 'https://github.com/gollum/rugged_adapter/', branch: 'find_branches'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 gemspec :name => 'gollum-lib'
 gem 'irb'
+gem 'gollum-rugged_adapter', :git => 'https://github.com/gollum/rugged_adapter/', :branch => 'find_branches'

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
-
 gemspec :name => 'gollum-lib'
+gem 'irb'

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,4 @@ gem 'irb'
 # Chaanges to this branch require corresponding changes in the adapters, see https://github.com/gollum/gollum-lib/pull/424
 if RUBY_PLATFORM == 'java'
   gem 'gollum-rjgit_adapter', git: 'https://github.com/dometto/gollum-lib_rjgit_adapter/', branch: 'find_branch'
-else
-  gem 'gollum-rugged_adapter', git: 'https://github.com/gollum/rugged_adapter/', branch: 'find_branches'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,8 @@ source 'https://rubygems.org'
 gemspec :name => 'gollum-lib'
 gem 'irb'
 
+if RUBY_PLATFORM == 'java' then
+  group :development do
+    gem 'activesupport', '~> 6.0'
+  end
+end

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 gemspec :name => 'gollum-lib'
 gem 'irb'
 
+# Chaanges to this branch require corresponding changes in the adapters, see https://github.com/gollum/gollum-lib/pull/424
 if RUBY_PLATFORM == 'java'
   gem 'gollum-rjgit_adapter', git: 'https://github.com/dometto/gollum-lib_rjgit_adapter/', branch: 'find_branch'
 else

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,3 @@ source 'https://rubygems.org'
 gemspec :name => 'gollum-lib'
 gem 'irb'
 
-# Chaanges to this branch require corresponding changes in the adapters, see https://github.com/gollum/gollum-lib/pull/424
-if RUBY_PLATFORM == 'java'
-  gem 'gollum-rjgit_adapter', git: 'https://github.com/dometto/gollum-lib_rjgit_adapter/', branch: 'find_branch'
-end

--- a/LATEST_CHANGES.md
+++ b/LATEST_CHANGES.md
@@ -1,0 +1,4 @@
+# 6.0
+
+* Default to local PlantUML server for security. #412. (@manofstick)
+* Allow use of default branch name `main` or `master. Resolves https://github.com/gollum/gollum/issues/1813. (@dometto)

--- a/gollum-lib.gemspec
+++ b/gollum-lib.gemspec
@@ -3,7 +3,7 @@ require File.join(File.dirname(__FILE__), 'lib', 'gollum-lib', 'version.rb')
 # This file needs to conditionally define the default adapter for MRI and Java, because this is the file that is included from the Gemfile.
 # In addition, the default Java adapter needs to be defined in gollum-lib_java.gemspec beause that file is used to *build* the Java gem.
 if RUBY_PLATFORM == 'java' then
-  default_adapter = ['gollum-rjgit_adapter', '~> 0.6']
+  default_adapter = ['gollum-rjgit_adapter', '~> 1.0']
 else
   default_adapter = ['gollum-rugged_adapter', '~> 2.0']
 end

--- a/gollum-lib.gemspec
+++ b/gollum-lib.gemspec
@@ -5,6 +5,6 @@ require File.join(File.dirname(__FILE__), 'lib', 'gollum-lib', 'version.rb')
 if RUBY_PLATFORM == 'java' then
   default_adapter = ['gollum-rjgit_adapter', '~> 0.6']
 else
-  default_adapter = ['gollum-rugged_adapter', '~> 1.0']
+  default_adapter = ['gollum-rugged_adapter', '~> 2.0']
 end
 Gem::Specification.new &specification(Gollum::Lib::VERSION, default_adapter)

--- a/gollum-lib_java.gemspec
+++ b/gollum-lib_java.gemspec
@@ -1,4 +1,4 @@
 require File.join(File.dirname(__FILE__), 'gemspec.rb')
 require File.join(File.dirname(__FILE__), 'lib', 'gollum-lib', 'version.rb')
-default_adapter = ['gollum-rjgit_adapter', '~> 0.6']
+default_adapter = ['gollum-rjgit_adapter', '~> 1.0']
 Gem::Specification.new &specification(Gollum::Lib::VERSION, default_adapter, "java") 

--- a/lib/gollum-lib/wiki.rb
+++ b/lib/gollum-lib/wiki.rb
@@ -7,7 +7,7 @@ module Gollum
 
     class << self
       # Sets the default ref for the wiki.
-      attr_writer :default_ref
+      attr_writer :default_refs
 
       # Sets the default name for commits.
       attr_writer :default_committer_name
@@ -19,8 +19,16 @@ module Gollum
       # These defaults can be overridden by options passed directly to initialize()
       attr_writer :default_options
 
-      def default_ref
-        @default_ref || 'master'
+      def find_default_ref(repo)
+        result = repo.find_branch(self.default_refs) || Gollum::Git.global_default_branch || 'main'
+        if result == 'master'
+          puts "DEPRECATION WARNING: Defaulting to discovered branch 'master'. This will be removed as a default branch name in the next major release. Please switch to using 'main' as branch name."
+        end
+        result
+      end
+
+      def default_refs
+        @default_refs || ['main', 'master']
       end
 
       def default_committer_name
@@ -132,7 +140,7 @@ module Gollum
       @access               = options.fetch :access, GitAccess.new(path, @page_file_dir, @repo_is_bare)
       @base_path            = options.fetch :base_path, "/"
       @repo                 = @access.repo
-      @ref                  = options.fetch :ref, self.class.default_ref
+      @ref                  = options.fetch :ref, self.class.find_default_ref(@repo)
       @universal_toc        = options.fetch :universal_toc, false
       @mathjax              = options.fetch :mathjax, false
       @global_tag_lookup    = options.fetch :global_tag_lookup, false

--- a/lib/gollum-lib/wiki.rb
+++ b/lib/gollum-lib/wiki.rb
@@ -20,7 +20,7 @@ module Gollum
       attr_writer :default_options
 
       def find_default_ref(repo)
-        result = repo.find_branch(self.default_refs) || Gollum::Git.global_default_branch || 'main'
+        result = repo.find_branch(self.default_refs) || Gollum::Git.global_default_branch || self.default_refs.first
         if result == 'master'
           puts "DEPRECATION WARNING: Defaulting to discovered branch 'master'. This will be removed as a default branch name in the next major release. Please switch to using 'main' as branch name."
         end
@@ -28,7 +28,7 @@ module Gollum
       end
 
       def default_refs
-        @default_refs || ['main', 'master']
+        @default_refs || ['master', 'main']
       end
 
       def default_committer_name

--- a/lib/gollum-lib/wiki.rb
+++ b/lib/gollum-lib/wiki.rb
@@ -20,11 +20,7 @@ module Gollum
       attr_writer :default_options
 
       def find_default_ref(repo)
-        result = repo.find_branch(self.default_refs) || Gollum::Git.global_default_branch || self.default_refs.first
-        if result == 'master'
-          puts "DEPRECATION WARNING: Defaulting to discovered branch 'master'. This will be removed as a default branch name in the next major release. Please switch to using 'main' as branch name."
-        end
-        result
+        repo.find_branch(self.default_refs) || Gollum::Git.global_default_branch || self.default_refs.first
       end
 
       def default_refs

--- a/test/test_wiki.rb
+++ b/test/test_wiki.rb
@@ -100,7 +100,7 @@ context "Wiki" do
     begin
       wiki  = Gollum::Wiki.new(@path)
       index = wiki.repo.index
-      index.read_tree 'main'
+      index.read_tree 'master'
       index.add('Foobar/Elrond.md', 'Baz')
       index.commit 'Add Foobar/Elrond.', [wiki.repo.head.commit], Gollum::Git::Actor.new('Tom Preston-Werner', 'tom@github.com')
 

--- a/test/test_wiki.rb
+++ b/test/test_wiki.rb
@@ -100,7 +100,7 @@ context "Wiki" do
     begin
       wiki  = Gollum::Wiki.new(@path)
       index = wiki.repo.index
-      index.read_tree 'master'
+      index.read_tree 'main'
       index.add('Foobar/Elrond.md', 'Baz')
       index.commit 'Add Foobar/Elrond.', [wiki.repo.head.commit], Gollum::Git::Actor.new('Tom Preston-Werner', 'tom@github.com')
 


### PR DESCRIPTION
Resolves https://github.com/gollum/gollum/issues/1813

Requires these changes to the adapter: https://github.com/gollum/rugged_adapter/pull/55 (RJGit adapter support forthcoming)

This is the easiest way I could see to support both `master` and `main` as default branches. The default ref will be determined as follows, in order:

1. is there an explicit branch set by the user (`--ref`)?
2. If not, try the branch names in `Wiki.default_refs` in order. If any of them exist, default to it.
3. If not, see if there is a global git default branch name set and use it.
4. If not, use `main`

NB: if step 2 fails, we still want to default to something, as the `gollum-lib` API supports working with an empty repo (gollum can make the first commit, but then needs to know on what branch).

Would this be an acceptable solution? A simpler alternative would be to just drop support for `master` altogether, but I think a middle way might be good.

Questions:

* What do we want to have in `Wiki.default_refs`? Presently I went for `['main', 'master']`. Anything else?
* Do we want to print the deprecation message for `master` at all? Or print it only outside of tests?


