### PR TITLE
Move Sanitize filter further to front of filter chain, don't sanitize Macros seperately

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -225,21 +225,3 @@ task :changelog do
   `cat #{history_file} >> #{temp.path}`
   `cat #{temp.path} > #{history_file}`
 end
-
-desc 'Precompile assets'
-task :precompile do
-  require './lib/gollum/app.rb'
-  Precious::App.set(:environment, :production)
-  env = Precious::Assets.sprockets
-  path = ENV.fetch('GOLLUM_ASSETS_PATH', ::File.join(File.dirname(__FILE__), 'lib/gollum/public/assets'))
-  manifest = Sprockets::Manifest.new(env, path)
-  Sprockets::Helpers.configure do |config|
-    config.environment = env
-    config.prefix      = Precious::Assets::ASSET_URL
-    config.digest      = true
-    config.public_path = path
-    config.manifest    = manifest
-  end
-  puts "Precompiling assets to #{path}..."
-  manifest.compile(Precious::Assets::MANIFEST)
-end

--- a/lib/gollum-lib/filter/macro.rb
+++ b/lib/gollum-lib/filter/macro.rb
@@ -55,6 +55,6 @@ class Gollum::Filter::Macro < Gollum::Filter
       end
     end
 
-    sanitize(data)
+    data
   end
 end

--- a/lib/gollum-lib/wiki.rb
+++ b/lib/gollum-lib/wiki.rb
@@ -152,7 +152,7 @@ module Gollum
       @per_page_uploads     = options.fetch :per_page_uploads, false
       @metadata             = options.fetch :metadata, {}
       @filter_chain         = options.fetch :filter_chain,
-                                            [:YAML, :BibTeX, :PlainText, :CriticMarkup, :TOC, :RemoteCode, :Code, :Macro, :Emoji, :Sanitize, :PlantUML, :Tags, :PandocBib, :Render]
+                                            [:YAML, :BibTeX, :PlainText, :CriticMarkup, :TOC, :Sanitize, :RemoteCode, :Code, :Macro, :Emoji, :PlantUML, :Tags, :PandocBib, :Render]
       @filter_chain.delete(:Emoji) unless options.fetch :emoji, false
       @filter_chain.delete(:PandocBib) unless ::Gollum::MarkupRegisterUtils.using_pandoc?
       @filter_chain.delete(:CriticMarkup) unless options.fetch :critic_markup, false

--- a/test/test_macros.rb
+++ b/test/test_macros.rb
@@ -184,7 +184,7 @@ context "Macros" do
     assert_match /<div class=\"flash flash-error\"><svg.*class=\"octicon octicon-zap mr-2\".*Macro Error for Octicon: Couldn't find octicon symbol for "foobar".*/, @wiki.pages[0].formatted_data
   end
 
-  test "Audio macro escapes HTML" do
+  test "Macros escape HTML" do
     @wiki.write_page("AudioXSSTest", :markdown, '<<Audio(a"></audio><input>)>>', commit_details)
     assert_not_match /<input/, @wiki.pages[0].formatted_data
   end


### PR DESCRIPTION
Resolves #408.

I couldn't move the Sanitize filter all the way to the front since that caused the TOC to render incorrectly. But now it's in front of (i.e. executed after) the Macro filter and others, which is safer. Removed the separate sanitization step in the Macro filter.

We could still try placing the BibTeX filter behind the Sanitize filter so that gets sanitized as well.

There is a separate sanitization call in the YAML filter too, but that's unfortunately necessary because metadata gets parsed independently from the rest of the page.