### PR TITLE
Don't sanitize controls attribute

### DIFF
--- a/lib/gollum-lib/macro/audio.rb
+++ b/lib/gollum-lib/macro/audio.rb
@@ -2,7 +2,7 @@ module Gollum
   class Macro
     class Audio < Gollum::Macro
       def render (fname)
-        "<audio width=\"100%\" height=\"100%\" src=\"#{CGI::escapeHTML(fname)}\" controls=\"\"> HTML5 audio is not supported on this Browser.</audio>"
+        "<audio width=\"100%\" height=\"100%\" src=\"#{CGI::escapeHTML(fname)}\" controls=\"true\"> HTML5 audio is not supported on this Browser.</audio>"
       end
     end
   end

--- a/lib/gollum-lib/macro/video.rb
+++ b/lib/gollum-lib/macro/video.rb
@@ -2,7 +2,7 @@ module Gollum
   class Macro
     class Video < Gollum::Macro
       def render (fname)
-        "<video width=\"100%\" height=\"100%\" src=\"#{CGI::escapeHTML(fname)}\" controls=\"\"> HTML5 video is not supported on this Browser.</video>"
+        "<video width=\"100%\" height=\"100%\" src=\"#{CGI::escapeHTML(fname)}\" controls=\"true\"> HTML5 video is not supported on this Browser.</video>"
       end
     end
   end

--- a/lib/gollum-lib/sanitization.rb
+++ b/lib/gollum-lib/sanitization.rb
@@ -1,4 +1,5 @@
 ::Loofah::HTML5::SafeList::ACCEPTABLE_PROTOCOLS.add('apt')
+::Loofah::HTML5::SafeList::ALLOWED_ATTRIBUTES.add('controls')
 
 module Gollum
   class Sanitization

--- a/test/test_macros.rb
+++ b/test/test_macros.rb
@@ -200,4 +200,10 @@ context "Macros" do
     @wiki.write_page("_Footer", :markdown, "<<Series(test)>>", commit_details)
     assert_match /Next(.*)test-2&lt;span&gt;/, @wiki.page("test-1").footer.formatted_data
   end
+
+  test "Control attributes for Audio and Video are not sanitized" do
+    @wiki.write_page("AudioTagTest", :markdown, "<<Audio(foo)>>\n<<Video(bar)>>", commit_details)
+    # The Macros must return controls=true until https://github.com/flavorjones/loofah/issues/242 is resolved
+    assert_match /<audio (.*)controls(.*)>(.*)<video (.*)controls(.*)>/m, @wiki.pages[0].formatted_data
+  end
 end


### PR DESCRIPTION
Resolves https://github.com/gollum/gollum/issues/1856

Our Video and Audio Macros are rendering `controls` attributes in the `<video>` and `<audio>` tags. Two problems:

1. `controls` was not added to Loofah's safelist. This was not a problem until we started sanitizing Macro output (in #402).
2. even when added to the safelist, the `controls` attribute is still being sanitized due to https://github.com/flavorjones/loofah/issues/242

This PR fixes 1 by adding `controls` to the safelist, and 2 by using a workaround: `controls="true"` as opposed to just `controls` is not sanitized by loofah. The latter should not be necessary, and when the loofah issue is resolved we can revert that change.