### PR TITLE
Add session to hook 

### DIFF
--- a/lib/gollum-lib/committer.rb
+++ b/lib/gollum-lib/committer.rb
@@ -18,6 +18,7 @@ module Gollum
     #           :message   - The String commit message.
     #           :name      - The String author full name.
     #           :email     - The String email address.
+    #           :note      - Optional String containing info about the commit. Not used, but can be accessed from inside the :post_commit Hook.
     #           :parent    - Optional Gollum::Git::Commit parent to this update.
     #           :tree      - Optional String SHA of the tree to create the
     #                        index from.


### PR DESCRIPTION
Relates to https://github.com/gollum/gollum/issues/1766

This allows passing in a `:session` key to the `Committer.new` options hash. This Hash is then passed along to the `:post_commit` Hook context.