### PR TITLE
Allow defining custom rendering Procs for a format

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+# 5.2.1 / 2022-09-13
+
+* Fixed: 'controls' attribute in audio and video tags should not be sanitized. #430 (@dometto)
+
+
 # 5.2 / 2022-05-28
 
 * Conditionally render "editable" heading classes. Resolves https://github.com/gollum/gollum/issues/1785 (@benjaminwil)

--- a/Rakefile
+++ b/Rakefile
@@ -225,21 +225,3 @@ task :changelog do
   `cat #{history_file} >> #{temp.path}`
   `cat #{temp.path} > #{history_file}`
 end
-
-desc 'Precompile assets'
-task :precompile do
-  require './lib/gollum/app.rb'
-  Precious::App.set(:environment, :production)
-  env = Precious::Assets.sprockets
-  path = ENV.fetch('GOLLUM_ASSETS_PATH', ::File.join(File.dirname(__FILE__), 'lib/gollum/public/assets'))
-  manifest = Sprockets::Manifest.new(env, path)
-  Sprockets::Helpers.configure do |config|
-    config.environment = env
-    config.prefix      = Precious::Assets::ASSET_URL
-    config.digest      = true
-    config.public_path = path
-    config.manifest    = manifest
-  end
-  puts "Precompiling assets to #{path}..."
-  manifest.compile(Precious::Assets::MANIFEST)
-end

--- a/lib/gollum-lib/filter/render.rb
+++ b/lib/gollum-lib/filter/render.rb
@@ -6,7 +6,11 @@ class Gollum::Filter::Render < Gollum::Filter
       working_dir = Pathname.new(@markup.wiki.path).join(@markup.dir)
       working_dir = working_dir.exist? ? working_dir.to_s : '.'
       Dir.chdir(working_dir) do
-        data = GitHub::Markup.render_s(@markup.format, data)
+        if block = @markup.custom_renderer
+          data = block.call(data)
+        else
+          data = GitHub::Markup.render_s(@markup.format, data)
+        end
       end
       if data.nil?
         raise "There was an error converting #{@markup.name} to HTML."

--- a/lib/gollum-lib/macro/audio.rb
+++ b/lib/gollum-lib/macro/audio.rb
@@ -2,7 +2,7 @@ module Gollum
   class Macro
     class Audio < Gollum::Macro
       def render (fname)
-        "<audio width=\"100%\" height=\"100%\" src=\"#{CGI::escapeHTML(fname)}\" controls=\"\"> HTML5 audio is not supported on this Browser.</audio>"
+        "<audio width=\"100%\" height=\"100%\" src=\"#{CGI::escapeHTML(fname)}\" controls=\"true\"> HTML5 audio is not supported on this Browser.</audio>"
       end
     end
   end

--- a/lib/gollum-lib/macro/video.rb
+++ b/lib/gollum-lib/macro/video.rb
@@ -2,7 +2,7 @@ module Gollum
   class Macro
     class Video < Gollum::Macro
       def render (fname)
-        "<video width=\"100%\" height=\"100%\" src=\"#{CGI::escapeHTML(fname)}\" controls=\"\"> HTML5 video is not supported on this Browser.</video>"
+        "<video width=\"100%\" height=\"100%\" src=\"#{CGI::escapeHTML(fname)}\" controls=\"true\"> HTML5 video is not supported on this Browser.</video>"
       end
     end
   end

--- a/lib/gollum-lib/markup.rb
+++ b/lib/gollum-lib/markup.rb
@@ -61,7 +61,9 @@ module Gollum
           :extensions => new_extension,
           :reverse_links => options.fetch(:reverse_links, false),
           :skip_filters => options.fetch(:skip_filters, nil),
-          :enabled => options.fetch(:enabled, true) }
+          :enabled => options.fetch(:enabled, true),
+          :render => options.fetch(:render, nil)
+        }
         @extensions.concat(new_extension)
       end
     end
@@ -102,6 +104,10 @@ module Gollum
       self.class.formats[@format][:reverse_links]
     end
 
+    def custom_renderer
+      self.class.formats[@format].fetch(:render, nil)
+    end
+
     # Whether or not a particular filter should be skipped for this format.
     def skip_filter?(filter)
       if self.class.formats[@format][:skip_filters].respond_to?(:include?)
@@ -119,7 +125,7 @@ module Gollum
     # filter_chain - the chain to process
     #
     # Returns the formatted data
-    def process_chain(data, filter_chain)
+    def process_chain(data, filter_chain, &block)
       # First we extract the data through the chain...
       filter_chain.each do |filter|
         data = filter.extract(data)

--- a/lib/gollum-lib/sanitization.rb
+++ b/lib/gollum-lib/sanitization.rb
@@ -1,4 +1,5 @@
 ::Loofah::HTML5::SafeList::ACCEPTABLE_PROTOCOLS.add('apt')
+::Loofah::HTML5::SafeList::ALLOWED_ATTRIBUTES.add('controls')
 
 module Gollum
   class Sanitization

--- a/lib/gollum-lib/version.rb
+++ b/lib/gollum-lib/version.rb
@@ -1,5 +1,5 @@
 module Gollum
   module Lib
-    VERSION = '5.2'
+    VERSION = '5.2.1'
   end
 end

--- a/test/test_macros.rb
+++ b/test/test_macros.rb
@@ -200,4 +200,10 @@ context "Macros" do
     @wiki.write_page("_Footer", :markdown, "<<Series(test)>>", commit_details)
     assert_match /Next(.*)test-2&lt;span&gt;/, @wiki.page("test-1").footer.formatted_data
   end
+
+  test "Control attributes for Audio and Video are not sanitized" do
+    @wiki.write_page("AudioTagTest", :markdown, "<<Audio(foo)>>\n<<Video(bar)>>", commit_details)
+    # The Macros must return controls=true until https://github.com/flavorjones/loofah/issues/242 is resolved
+    assert_match /<audio (.*)controls(.*)>(.*)<video (.*)controls(.*)>/m, @wiki.pages[0].formatted_data
+  end
 end

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -100,6 +100,7 @@ context "Markup" do
 
   test 'github-markup knows about gollum markups' do
     markups_with_render_filter = Gollum::Markup.formats.select do |k, v|
+      return false if v[:render]
       case v[:skip_filters]
       when Array
         !v[:skip_filters].include?(:Render)
@@ -112,6 +113,16 @@ context "Markup" do
     markups_with_render_filter.each do |name, info|
       assert ::GitHub::Markup.markups.key?(name), "GitHub::Markup does not know about format #{name}"
     end
+  end
+
+  test 'formats can define custom rendering block' do
+    Gollum::Markup.register(
+        :xyz, "Xyz", :extensions => ['xyz'],
+        :enabled => true,
+        :render => proc {|content| content.upcase },
+    )
+    page = @wiki.write_page('XyzTest', :xyz, 'helloworld', commit_details)
+    assert_equal 'HELLOWORLD', @wiki.page('XyzTest').formatted_data
   end
 
   #########################################################################


### PR DESCRIPTION
This change to the API allows users a bit more freedom to define custom formats. Currently, we are limited to formats that exist in `Github::Markup`. This PR allows us to bypass `Github::Markup` entirely when defining a format: instead, the `Render` filter will directly call a user-supplied block. 

As an example, with this change, I was able to get rudimentary support for [Fountain](https://github.com/gollum/gollum/issues/1715) working with the following snippet in `config.rb`:

```ruby
fountain_lua = '/path/to/.pandoc/filters/fountain.lua'
require 'pandoc-ruby'
Gollum::Markup.register(
    :fountain, "Fountain", :extensions => ['fountain'],
    :enabled => Gollum::MarkupRegisterUtils::gem_exists?('pandoc-ruby'),
    :render => proc {|content| ::PandocRuby.convert(content, f: fountain_lua, to: :html) }
)
```

But of course the `:render` `Proc` can contain anything, it's not limited to calling `PandocRuby`.

Feedback very welcome!