### PR TITLE
Allow defining rendering proc for formats

### DIFF
--- a/lib/gollum-lib/filter/render.rb
+++ b/lib/gollum-lib/filter/render.rb
@@ -6,7 +6,11 @@ class Gollum::Filter::Render < Gollum::Filter
       working_dir = Pathname.new(@markup.wiki.path).join(@markup.dir)
       working_dir = working_dir.exist? ? working_dir.to_s : '.'
       Dir.chdir(working_dir) do
-        data = GitHub::Markup.render_s(@markup.format, data)
+        if block = @markup.custom_renderer
+          data = block.call(data)
+        else
+          data = GitHub::Markup.render_s(@markup.format, data)
+        end
       end
       if data.nil?
         raise "There was an error converting #{@markup.name} to HTML."

--- a/lib/gollum-lib/markup.rb
+++ b/lib/gollum-lib/markup.rb
@@ -61,7 +61,9 @@ module Gollum
           :extensions => new_extension,
           :reverse_links => options.fetch(:reverse_links, false),
           :skip_filters => options.fetch(:skip_filters, nil),
-          :enabled => options.fetch(:enabled, true) }
+          :enabled => options.fetch(:enabled, true),
+          :render => options.fetch(:render, nil)
+        }
         @extensions.concat(new_extension)
       end
     end
@@ -102,6 +104,10 @@ module Gollum
       self.class.formats[@format][:reverse_links]
     end
 
+    def custom_renderer
+      self.class.formats[@format].fetch(:render, nil)
+    end
+
     # Whether or not a particular filter should be skipped for this format.
     def skip_filter?(filter)
       if self.class.formats[@format][:skip_filters].respond_to?(:include?)
@@ -119,7 +125,7 @@ module Gollum
     # filter_chain - the chain to process
     #
     # Returns the formatted data
-    def process_chain(data, filter_chain)
+    def process_chain(data, filter_chain, &block)
       # First we extract the data through the chain...
       filter_chain.each do |filter|
         data = filter.extract(data)

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -100,6 +100,7 @@ context "Markup" do
 
   test 'github-markup knows about gollum markups' do
     markups_with_render_filter = Gollum::Markup.formats.select do |k, v|
+      return false if v[:render]
       case v[:skip_filters]
       when Array
         !v[:skip_filters].include?(:Render)
@@ -112,6 +113,16 @@ context "Markup" do
     markups_with_render_filter.each do |name, info|
       assert ::GitHub::Markup.markups.key?(name), "GitHub::Markup does not know about format #{name}"
     end
+  end
+
+  test 'formats can define custom rendering block' do
+    Gollum::Markup.register(
+        :xyz, "Xyz", :extensions => ['xyz'],
+        :enabled => true,
+        :render => proc {|content| content.upcase },
+    )
+    page = @wiki.write_page('XyzTest', :xyz, 'helloworld', commit_details)
+    assert_equal 'HELLOWORLD', @wiki.page('XyzTest').formatted_data
   end
 
   #########################################################################


### PR DESCRIPTION
This change to the API allows users a bit more freedom to define custom formats. Currently, we are limited to formats that exist in `Github::Markup`. This PR allows us to bypass `Github::Markup` entirely when defining a format: instead, the `Render` filter will directly call a user-supplied block. 

As an example, with this change, I was able to get rudimentary support for [Fountain](https://github.com/gollum/gollum/issues/1715) working with the following snippet in `config.rb`:

```ruby
fountain_lua = '/path/to/.pandoc/filters/fountain.lua'
require 'pandoc-ruby'
Gollum::Markup.register(
    :fountain, "Fountain", :extensions => ['fountain'],
    :enabled => Gollum::MarkupRegisterUtils::gem_exists?('pandoc-ruby'),
    :render => proc {|content| ::PandocRuby.convert(content, f: fountain_lua, to: :html) }
)
```

But of course the `:render` `Proc` can contain anything, it's not limited to calling `PandocRuby`.

Feedback very welcome!