### PR TITLE
Preserve relative links for absent pages

### DIFF
--- a/lib/gollum-lib/filter/tags.rb
+++ b/lib/gollum-lib/filter/tags.rb
@@ -231,7 +231,13 @@ class Gollum::Filter::Tags < Gollum::Filter
       name = page ? path_to_link_text(link) : link
     end
 
-    link = page ? page.escaped_url_path : ERB::Util.url_encode(link).force_encoding('utf-8')
+    if page
+      link = page.escaped_url_path
+    else
+      link = Pathname.new(link).relative? ? "#{@markup.dir.to_s}/#{link}" : link
+      link = ERB::Util.url_encode(link).force_encoding('utf-8')
+    end
+
     generate_link(link, name, extra, presence)
   end
 

--- a/lib/gollum-lib/helpers.rb
+++ b/lib/gollum-lib/helpers.rb
@@ -7,8 +7,7 @@ module Gollum
     def trim_leading_slashes(url)
       return nil if url.nil?
       url.gsub!('%2F', '/')
-      return '/' + url.gsub(/^\/+/, '') if url[0, 1] == '/'
-      url
+      (Pathname.new('/') + url).cleanpath.to_s
     end
     
     # Take a link path and turn it into a string for display as link text.

--- a/lib/gollum-lib/helpers.rb
+++ b/lib/gollum-lib/helpers.rb
@@ -3,11 +3,12 @@
 module Gollum
   module Helpers
     
-    # If url starts with a leading slash, trim down its number of leading slashes to 1. Else, return url unchanged.
+    # Replace url-encoded slashes ('%2F') with slashes
+    # Clean up double slashes
     def trim_leading_slashes(url)
       return nil if url.nil?
       url.gsub!('%2F', '/')
-      (Pathname.new('/') + url).cleanpath.to_s
+      Pathname.new(url).cleanpath.to_s
     end
     
     # Take a link path and turn it into a string for display as link text.

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -227,6 +227,27 @@ context "Markup" do
     assert_match regx, @wiki.page(page.name, sha1).formatted_data
     assert_match regx, @wiki.page(page.name, sha2).formatted_data
   end
+  
+  test "absent relative page link from subdirectory" do
+    index = @wiki.repo.index
+    index.add("subdir/Bilbo-Baggins.md", "a [[Foo|Doesntexist]] b")
+    index.commit("Add files")
+
+    page   = @wiki.page("subdir/Bilbo-Baggins")
+    output = Gollum::Markup.new(page).render
+    assert_html_equal %{<p>a <a class=\"internal absent\" href="/subdir/Doesntexist">Foo</a> b</p>}, output
+  end
+
+  test "absent absolute page link from subdirectory" do
+    index = @wiki.repo.index
+    index.add("subdir/Bilbo-Baggins.md", "a [[Foo|/Doesntexist]] b")
+    index.commit("Add files")
+
+    page   = @wiki.page("subdir/Bilbo-Baggins")
+    output = Gollum::Markup.new(page).render
+    assert_html_equal %{<p>a <a class=\"internal absent\" href="/Doesntexist">Foo</a> b</p>}, output
+  end
+
 
   test "absent page link" do
     @wiki.write_page("Tolkien", :markdown, "a [[J. R. R. Tolkien]]'s b", commit_details)


### PR DESCRIPTION
Resolves https://github.com/gollum/gollum/issues/1761

If a link to `Foo` from a page within a directory `subdir` is broken, we want the link to point to `subdir/Foo` instead of `/Foo`. (A broken absolute link to `/Foo` should point to `/Foo`, of course.)