### PR TITLE
Support notes

### DIFF
--- a/LATEST_CHANGES.md
+++ b/LATEST_CHANGES.md
@@ -2,3 +2,4 @@
 
 * Default to local PlantUML server for security. #412. (@manofstick)
 * Allow use of default branch name `main` or `master. Resolves https://github.com/gollum/gollum/issues/1813. (@dometto)
+* Support use of commit notes in Gollum::Committer. (@dometto, @bartkamphorst)

--- a/lib/gollum-lib/committer.rb
+++ b/lib/gollum-lib/committer.rb
@@ -129,6 +129,7 @@ module Gollum
       @callbacks.each do |cb|
         cb.call(self, sha1)
       end
+      @wiki.repo.commit(sha1).note=@options[:note] if @options[:note]
       Hook.execute(:post_commit, self, sha1)
       sha1
     end

--- a/test/test_committer.rb
+++ b/test/test_committer.rb
@@ -135,3 +135,20 @@ context "Wiki" do
     @wiki.update_page(page, page.name, format, "# Elrond", commit_details())
   end
 end
+
+context "Committer with a writable wiki" do
+  setup do
+    @path = cloned_testpath("examples/lotr.git")
+    @wiki = Gollum::Wiki.new(@path)
+  end
+
+  test "supports notes" do
+    committer = Gollum::Committer.new(@wiki, note: 'My notes')
+    committer.commit
+    assert_equal @wiki.repo.head.commit.note, 'My notes'
+  end
+
+  teardown do
+    FileUtils.rm_rf(@path)
+  end
+end


### PR DESCRIPTION
This will fail until we merge https://github.com/gollum/rugged_adapter/pull/57 and https://github.com/gollum/rjgit_adapter/pull/24 and release the new versions of the adapters.