### PR TITLE
Improve performance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,7 @@ gemspec :name => 'gollum-lib'
 gem 'irb'
 
 if RUBY_PLATFORM == 'java' then
-  gem 'gollum-rjgit_adapter', git: 'https://github.com/dometto/gollum-lib_rjgit_adapter', branch: 'tree_find_blob'
   group :development do
     gem 'activesupport', '~> 6.0'
   end
-else
-  gem 'gollum-rugged_adapter', git: 'https://github.com/gollum/rugged_adapter'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ gemspec :name => 'gollum-lib'
 gem 'irb'
 
 if RUBY_PLATFORM == 'java' then
-  gem 'gollum-rugged_adapter', git: 'gollum-lib_rjgit_adapter', branch: 'tree_find_blob'
+  gem 'gollum-rjgit_adapter', git: 'https://github.com/dometto/gollum-lib_rjgit_adapter', branch: 'tree_find_blob'
   group :development do
     gem 'activesupport', '~> 6.0'
   end

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 gemspec :name => 'gollum-lib'
 gem 'irb'
+gem 'gollum-rugged_adapter', git: 'https://github.com/dometto/rugged_adapter', branch: 'improve_tree_blobs'
 
 if RUBY_PLATFORM == 'java' then
   group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 gemspec :name => 'gollum-lib'
 gem 'irb'
-gem 'gollum-rugged_adapter', git: 'https://github.com/dometto/rugged_adapter', branch: 'improve_tree_blobs'
+gem 'gollum-rugged_adapter', git: 'https://github.com/gollum/rugged_adapter'
 
 if RUBY_PLATFORM == 'java' then
   group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,12 @@
 source 'https://rubygems.org'
 gemspec :name => 'gollum-lib'
 gem 'irb'
-gem 'gollum-rugged_adapter', git: 'https://github.com/gollum/rugged_adapter'
 
 if RUBY_PLATFORM == 'java' then
+  gem 'gollum-rugged_adapter', git: 'gollum-lib_rjgit_adapter', branch: 'tree_find_blob'
   group :development do
     gem 'activesupport', '~> 6.0'
   end
+else
+  gem 'gollum-rugged_adapter', git: 'https://github.com/gollum/rugged_adapter'
 end

--- a/gemspec.rb
+++ b/gemspec.rb
@@ -33,7 +33,7 @@ def specification(version, default_adapter, platform = nil)
     s.add_development_dependency 'kramdown', '~> 2.3'
     s.add_development_dependency 'kramdown-parser-gfm', '~> 1.1.0'
     s.add_development_dependency 'RedCloth', '~> 4.2.9'
-    s.add_development_dependency 'mocha', '~> 1.11'
+    s.add_development_dependency 'mocha', '~> 2.0'
     s.add_development_dependency 'shoulda', '~> 4.0'
     s.add_development_dependency 'wikicloth', '~> 0.8.3'
     s.add_development_dependency 'bibtex-ruby', '~> 6.0'

--- a/gollum-lib.gemspec
+++ b/gollum-lib.gemspec
@@ -3,8 +3,8 @@ require File.join(File.dirname(__FILE__), 'lib', 'gollum-lib', 'version.rb')
 # This file needs to conditionally define the default adapter for MRI and Java, because this is the file that is included from the Gemfile.
 # In addition, the default Java adapter needs to be defined in gollum-lib_java.gemspec beause that file is used to *build* the Java gem.
 if RUBY_PLATFORM == 'java' then
-  default_adapter = ['gollum-rjgit_adapter', '~> 1.0']
+  default_adapter = ['gollum-rjgit_adapter', '~> 2.0']
 else
-  default_adapter = ['gollum-rugged_adapter', '~> 2.0']
+  default_adapter = ['gollum-rugged_adapter', '~> 3.0']
 end
 Gem::Specification.new &specification(Gollum::Lib::VERSION, default_adapter)

--- a/gollum-lib_java.gemspec
+++ b/gollum-lib_java.gemspec
@@ -1,4 +1,4 @@
 require File.join(File.dirname(__FILE__), 'gemspec.rb')
 require File.join(File.dirname(__FILE__), 'lib', 'gollum-lib', 'version.rb')
-default_adapter = ['gollum-rjgit_adapter', '~> 1.0']
+default_adapter = ['gollum-rjgit_adapter', '~> 2.0']
 Gem::Specification.new &specification(Gollum::Lib::VERSION, default_adapter, "java") 

--- a/lib/gollum-lib/file.rb
+++ b/lib/gollum-lib/file.rb
@@ -72,7 +72,7 @@ module Gollum
     def initialize(wiki, blob, path, version, try_on_disk = false)
       @wiki         = wiki
       @blob         = blob
-      @path         = path.empty? ? blob.name : ::File.join(path, blob.name)
+      @path         = Pathname.new(::File.join('/', path, blob.name)).cleanpath.to_s[1..-1]
       @version      = version.is_a?(Gollum::Git::Commit) ? version : @wiki.commit_for(version)
       get_disk_reference if try_on_disk
     end

--- a/lib/gollum-lib/file.rb
+++ b/lib/gollum-lib/file.rb
@@ -40,19 +40,19 @@ module Gollum
     # version - The String version ID to find.
     # try_on_disk - If true, try to return just a reference to a file
     #               that exists on the disk.
-    # global_match - If true, find a File matching path's filename, but not it's directory (so anywhere in the repo)
+    # global_match - If true, find a File matching path's filename, but not its directory (so anywhere in the repo)
     #
     # Returns a Gollum::File or nil if the file could not be found. Note
     # that if you specify try_on_disk=true, you may or may not get a file
     # for which on_disk? is actually true.
     def self.find(wiki, path, version, try_on_disk = false, global_match = false)
-      path_segments =  self.canonical_path(wiki.page_file_dir, path).split('/')
+      query_path =  self.canonical_path(wiki.page_file_dir, path)
+      path_segments = query_path.split('/')
       filename = path_segments.last
       dir = path_segments[0..-2].join('/')
 
-
-      if global_match
-        return nil
+      if global_match && self.respond_to?(:global_find) # Only implemented for Gollum::Page
+        return self.global_find(wiki, version, query_path, try_on_disk) 
       else
         begin
           root = wiki.commit_for(version.to_s)

--- a/lib/gollum-lib/file.rb
+++ b/lib/gollum-lib/file.rb
@@ -58,7 +58,7 @@ module Gollum
         return self.global_find(wiki, version, query_path, try_on_disk) 
       else
         begin
-          root = wiki.commit_for(version.to_s)
+          root = wiki.commit_for(version)
           return nil unless root
           tree = dir == '.' ? root.tree : root.tree / dir
           return nil unless tree

--- a/lib/gollum-lib/file.rb
+++ b/lib/gollum-lib/file.rb
@@ -9,7 +9,8 @@ module Gollum
     class << self
 
     # Get a canonical path to a file.
-    # Ensures that the result is always under page_file_dir (prevents path traversal).
+    # Ensures that the result is always under page_file_dir (prevents path traversal), if set.
+    # Removes leading slashes.
     #
     # path           - One or more String path elements to join together. `nil` values are ignored.
     # page_file_dir  - kwarg String, default: nil

--- a/lib/gollum-lib/file.rb
+++ b/lib/gollum-lib/file.rb
@@ -63,8 +63,8 @@ module Gollum
           return nil unless root
           tree = dir.empty? ? root.tree : root.tree / dir
           return nil unless tree
-          entry = tree.blobs.find do |blob|
-            path_compare(filename, blob.name, wiki.hyphened_tag_lookup, wiki.case_insensitive_tag_lookup)
+          entry = tree.find_blob do |blob_name|
+            path_compare(filename, blob_name, wiki.hyphened_tag_lookup, wiki.case_insensitive_tag_lookup)
           end
           entry ? self.new(wiki, entry, dir, version, try_on_disk) : nil
         rescue Gollum::Git::NoSuchShaFound

--- a/lib/gollum-lib/git_access.rb
+++ b/lib/gollum-lib/git_access.rb
@@ -161,15 +161,11 @@ module Gollum
       items = []
       tree.each do |entry|
         if entry[:type] == 'blob'
+          next if @page_file_dir && !entry[:path].start_with?("#{@page_file_dir}/")
           items << BlobEntry.new(entry[:sha], entry[:path], entry[:size], entry[:mode].to_i(8))
         end
       end
-      if (dir = @page_file_dir)
-        regex = /^#{dir}\//
-        items.select { |i| i.path =~ regex }
-      else
-        items
-      end
+      items
     end
 
     # Reads the content from the Git db at the given SHA.

--- a/lib/gollum-lib/git_access.rb
+++ b/lib/gollum-lib/git_access.rb
@@ -162,7 +162,7 @@ module Gollum
       tree.each do |entry|
         if entry[:type] == 'blob'
           next if @page_file_dir && !entry[:path].start_with?("#{@page_file_dir}/")
-          items << BlobEntry.new(entry[:sha], entry[:path], entry[:size], entry[:mode].to_i(8))
+          items << BlobEntry.new(entry[:sha], entry[:path], entry[:size], entry[:mode])
         end
       end
       items

--- a/lib/gollum-lib/page.rb
+++ b/lib/gollum-lib/page.rb
@@ -21,6 +21,18 @@ module Gollum
         path_compare(query, match_path, hyphened_tags, case_insensitive)
       end
 
+      def global_find(wiki, version, query, try_on_disk)
+        map = wiki.tree_map_for(version.to_s)
+        begin
+          entry = map.detect do |entry|
+            global_path_match(query, entry, wiki.hyphened_tag_lookup, wiki.case_insensitive_tag_lookup)
+          end
+          entry ? self.new(wiki, entry.blob(wiki.repo), entry.dir, version, try_on_disk) : nil
+        rescue Gollum::Git::NoSuchShaFound
+          nil
+        end
+      end
+
       def path_compare(query, match_path, hyphened_tags, case_insensitive)
         return false unless valid_extension?(match_path)
         cmp = valid_extension?(query) ? match_path : strip_filename(match_path)

--- a/lib/gollum-lib/page.rb
+++ b/lib/gollum-lib/page.rb
@@ -10,18 +10,22 @@ module Gollum
       #
       # query     - The String path to match.
       # entry     - The BlobEntry to check against.
-      # global_match - If true, find a File matching path's filename, but not its directory (so anywhere in the repo)
-      def path_match(query, entry, global_match = false, hyphened_tags = false, case_insensitive = false)
+      def global_path_match(query, entry, hyphened_tags = false, case_insensitive = false)
         return false if "#{entry.name}".empty?
         return false unless valid_extension?(entry.name)
-        entry_name = valid_extension?(query) ? entry.name : strip_filename(entry.name)     
         match_path = ::File.join([
-          '/',
-          global_match ? nil : entry.dir,
-        entry_name
+          '/', 
+          entry.dir,
+        entry.name
         ].compact)
         path_compare(query, match_path, hyphened_tags, case_insensitive)
       end
+
+      def path_compare(query, match_path, hyphened_tags, case_insensitive)
+        cmp = valid_extension?(query) ? match_path : strip_filename(match_path)
+        super(query, cmp, hyphened_tags, case_insensitive)
+      end
+
     end
 
     # Checks if a filename has a valid, registered extension

--- a/lib/gollum-lib/page.rb
+++ b/lib/gollum-lib/page.rb
@@ -22,6 +22,7 @@ module Gollum
       end
 
       def path_compare(query, match_path, hyphened_tags, case_insensitive)
+        return false unless valid_extension?(match_path)
         cmp = valid_extension?(query) ? match_path : strip_filename(match_path)
         super(query, cmp, hyphened_tags, case_insensitive)
       end

--- a/lib/gollum-lib/page.rb
+++ b/lib/gollum-lib/page.rb
@@ -6,7 +6,7 @@ module Gollum
     SUBPAGENAMES = [:header, :footer, :sidebar]
 
     class << self
-      # For use with self.find: returns true if the given query corresponds to the in-repo path of the BlobEntry. 
+      # For use with self.global_find: returns true if the given query corresponds to the in-repo path of the BlobEntry. 
       #
       # query     - The String path to match.
       # entry     - The BlobEntry to check against.

--- a/lib/gollum-lib/page.rb
+++ b/lib/gollum-lib/page.rb
@@ -13,11 +13,11 @@ module Gollum
       def global_path_match(query, entry, hyphened_tags = false, case_insensitive = false)
         return false if "#{entry.name}".empty?
         return false unless valid_extension?(entry.name)
-        match_path = ::File.join([
-          '/', 
+        match_path = Pathname.new('/').join(*[
           entry.dir,
-        entry.name
-        ].compact)
+          entry.name
+          ].compact
+        ).to_s
         path_compare(query, match_path, hyphened_tags, case_insensitive)
       end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -6,8 +6,8 @@ require 'fileutils'
 # external
 require 'rubygems'
 require 'shoulda'
-require 'mocha/test_unit'
 require 'minitest/reporters'
+require 'mocha/test_unit'
 require 'twitter_cldr'
 require 'tempfile'
 
@@ -24,7 +24,7 @@ require File.expand_path('../assertions', __FILE__)
 require 'i18n'
 I18n.enforce_available_locales = false
 
-MiniTest::Reporters.use!
+Minitest::Reporters.use!
 
 dir = File.dirname(File.expand_path(__FILE__))
 $LOAD_PATH.unshift(File.join(dir, '..', 'lib'))

--- a/test/test_file.rb
+++ b/test/test_file.rb
@@ -7,6 +7,15 @@ context "File" do
     @wiki = Gollum::Wiki.new(testpath("examples/lotr.git"))
   end
 
+  test 'canonical_path method does not allow path traversal exploit' do
+    page_file_dir = nil
+    dir = 'pages'
+    file = '../../'
+    assert_equal Gollum::File.canonical_path(dir, file, page_file_dir: page_file_dir), ''
+    page_file_dir = 'pages'
+    assert_equal Gollum::File.canonical_path(dir, file, page_file_dir: page_file_dir), 'pages'
+  end
+
   test "existing file" do
     commit = @wiki.repo.commits.first
     file   = @wiki.file("Mordor/todo.txt")

--- a/test/test_file.rb
+++ b/test/test_file.rb
@@ -14,6 +14,8 @@ context "File" do
     assert_equal Gollum::File.canonical_path(dir, file, page_file_dir: page_file_dir), ''
     page_file_dir = 'pages'
     assert_equal Gollum::File.canonical_path(dir, file, page_file_dir: page_file_dir), 'pages'
+    # also removes leading slashes
+    assert_equal Gollum::File.canonical_path('/foo/bar', page_file_dir: page_file_dir), 'pages/foo/bar'
   end
 
   test "existing file" do


### PR DESCRIPTION
In response to https://github.com/gollum/gollum/issues/1940#issuecomment-1381623614 I did some profiling and saw that *a lot* of time was being spent in the `Gollum::File.find`, iterating over entries in the treemap. Basically, gollum currently iterates over a Hash representation of *all* the blobs and trees in the repo (at a given commit). In a large repo, this means looping a long time (plus all the inefficiencies derived from instantiating objects associated with each entry in the repo). I decided to hack together another approach that does not rely on a treemap, and it was relatively straightforward to do.

Here are some quick profiling results, loading a page from the `nlab-conten` wiki referred to by @felixwellen:

* Rugged:
  *master: 26653ms
  * this branch: 784ms
* RJGit
  * master: 27704ms
  * this branch: 2279ms

(I used https://github.com/MiniProfiler/rack-mini-profiler to profile)

On a smaller repo (our `lotr.git`), tested with rugged, the speed increase is not noticeable (but I don't think it's any slower either ;)).

Feedback welcome!

Todo:

- [x] Fix symlinks (requires work on the adapters)
- [x] Implement global lookup