### PR TITLE
Fix Rakefile release task

### DIFF
--- a/LATEST_CHANGES.md
+++ b/LATEST_CHANGES.md
@@ -1,4 +1,4 @@
 # 5.2.2 / 2023-01-18
 
-* Bugfix release: set Nokogiri default XHTML conversion options more relaibly. See https://github.com/sparklemotion/nokogiri/issues/2761
+* Bugfix release: set Nokogiri default XHTML conversion options more reliably. See https://github.com/sparklemotion/nokogiri/issues/2761
 

--- a/LATEST_CHANGES.md
+++ b/LATEST_CHANGES.md
@@ -1,0 +1,4 @@
+# 5.2.2 / 2023-01-18
+
+* Bugfix release: set Nokogiri default XHTML conversion options more relaibly. See https://github.com/sparklemotion/nokogiri/issues/2761
+

--- a/Rakefile
+++ b/Rakefile
@@ -126,7 +126,7 @@ task :release => :build do
   Rake::Task[:changelog].execute
   sh "git commit --allow-empty -a -m 'Release #{version}'"
   sh "git pull --rebase origin master"
-  sh "git tag -n v#{version}"
+  sh "git tag v#{version} -m 'Release v#{version}'"
   sh "git push origin master"
   sh "git push origin v#{version}"
   sh "gem push pkg/#{name}-#{version}.gem"


### PR DESCRIPTION
The release flow failed for me because `git tag` suddenly asked for a message. Is it possible the default for `git tag` is now to require a tag message (rather than using "lightweight tags" by default)? If anyone knows anything about this I'd be much obliged. :)

In this PR I've fixed it by passing a message along with `git tag -m`.

Note: this should also be fixed in gollum.