### PR TITLE
Abstract use of Octicons to Gollum::Icon class

### DIFF
--- a/gemspec.rb
+++ b/gemspec.rb
@@ -26,9 +26,9 @@ def specification(version, default_adapter, platform = nil)
     s.add_dependency 'loofah', '~> 2.3'
     s.add_dependency 'github-markup', '~> 4.0'
     s.add_dependency 'gemojione', '~> 4.1'
-    s.add_dependency 'octicons', '~> 12.0'
     s.add_dependency 'twitter-text', '1.14.7'
-
+    s.add_dependency 'octicons', '> 12.0'
+    
     s.add_development_dependency 'org-ruby', '~> 0.9.9'
     s.add_development_dependency 'kramdown', '~> 2.3'
     s.add_development_dependency 'kramdown-parser-gfm', '~> 1.1.0'

--- a/lib/gollum-lib.rb
+++ b/lib/gollum-lib.rb
@@ -27,12 +27,14 @@ require File.expand_path('../gollum-lib/wiki', __FILE__)
 require File.expand_path('../gollum-lib/redirects', __FILE__)
 require File.expand_path('../gollum-lib/file', __FILE__)
 require File.expand_path('../gollum-lib/page', __FILE__)
+require File.expand_path('../gollum-lib/icon', __FILE__)
 require File.expand_path('../gollum-lib/macro', __FILE__)
 require File.expand_path('../gollum-lib/file_view', __FILE__)
 require File.expand_path('../gollum-lib/markup', __FILE__)
 require File.expand_path('../gollum-lib/markups', __FILE__)
 require File.expand_path('../gollum-lib/sanitization', __FILE__)
 require File.expand_path('../gollum-lib/filter', __FILE__)
+
 
 module Gollum
 

--- a/lib/gollum-lib/filter/macro.rb
+++ b/lib/gollum-lib/filter/macro.rb
@@ -1,5 +1,5 @@
 # ~*~ encoding: utf-8 ~*~
-require 'octicons'
+
 
 # Replace specified tokens with dynamically generated content.
 class Gollum::Filter::Macro < Gollum::Filter
@@ -48,9 +48,8 @@ class Gollum::Filter::Macro < Gollum::Filter
         begin
           Gollum::Macro.instance(macro, @markup.wiki, @markup.page).render(*args)
         rescue StandardError => e
-          icon = Octicons::Octicon.new('zap', {width: 24, height: 24})
-          icon.options[:class] << ' mr-2'
-          "<div class='flash flash-error'>#{icon.to_svg}Macro Error for #{macro}: #{e.message}</div>"
+          icon = Gollum::Icon.get_icon('zap', {width: 24, height: 24, class: 'mr-2'})
+          "<div class='flash flash-error'>#{icon}Macro Error for #{macro}: #{e.message}</div>"
         end
       end
     end

--- a/lib/gollum-lib/icon.rb
+++ b/lib/gollum-lib/icon.rb
@@ -1,0 +1,33 @@
+module Gollum
+  class Icon
+    # See if octicons gem is available
+    @@octicons = false
+    begin
+      require 'octicons'
+      @@octicons = true
+    rescue LoadError; end
+    
+    def self.get_icon(name, options={}, for_css=false)
+      defaults = {height: 16, width: 16, class: ''}
+      options = defaults.merge(options)
+      if for_css
+        options.delete(:height)
+        options.delete(:width)
+      end
+      if @@octicons && octicon = ::Octicons::Octicon.new(name, options)
+        octicon.to_svg
+      else
+        height = %Q(height="#{options[:height]}") if options[:height]
+        width = %Q(width="#{options[:width]}") if options[:width]
+        cls = %Q(class="octicon octicon-alert #{options[:class]}")
+        xmlns = %Q(xmlns="http://www.w3.org/2000/svg") if for_css
+        title = %Q(<title>Octicons are at present not available</title>)
+        viewbox = %Q(viewBox="0 0 24 24") if options[:width]
+        %Q(<svg #{height} #{width} #{cls} #{viewbox} #{xmlns} version="1.1" aria-hidden="true">#{title}<path d="M13 17.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0Zm-.25-8.25a.75.75 0 0 0-1.5 0v4.5a.75.75 0 0 0 1.5 0v-4.5Z"></path><path d="M9.836 3.244c.963-1.665 3.365-1.665 4.328 0l8.967 15.504c.963 1.667-.24 3.752-2.165 3.752H3.034c-1.926 0-3.128-2.085-2.165-3.752Zm3.03.751a1.002 1.002 0 0 0-1.732 0L2.168 19.499A1.002 1.002 0 0 0 3.034 21h17.932a1.002 1.002 0 0 0 .866-1.5L12.866 3.994Z"></path></svg>)
+      end
+    end
+    
+  end # class
+end # module
+
+

--- a/lib/gollum-lib/icon.rb
+++ b/lib/gollum-lib/icon.rb
@@ -17,14 +17,19 @@ module Gollum
       if @@octicons && octicon = ::Octicons::Octicon.new(name, options)
         octicon.to_svg
       else
-        height = %Q(height="#{options[:height]}") if options[:height]
-        width = %Q(width="#{options[:width]}") if options[:width]
-        cls = %Q(class="octicon octicon-alert #{options[:class]}")
-        xmlns = %Q(xmlns="http://www.w3.org/2000/svg") if for_css
-        title = %Q(<title>Octicons are at present not available</title>)
-        viewbox = %Q(viewBox="0 0 24 24") if options[:width]
-        %Q(<svg #{height} #{width} #{cls} #{viewbox} #{xmlns} version="1.1" aria-hidden="true">#{title}<path d="M13 17.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0Zm-.25-8.25a.75.75 0 0 0-1.5 0v4.5a.75.75 0 0 0 1.5 0v-4.5Z"></path><path d="M9.836 3.244c.963-1.665 3.365-1.665 4.328 0l8.967 15.504c.963 1.667-.24 3.752-2.165 3.752H3.034c-1.926 0-3.128-2.085-2.165-3.752Zm3.03.751a1.002 1.002 0 0 0-1.732 0L2.168 19.499A1.002 1.002 0 0 0 3.034 21h17.932a1.002 1.002 0 0 0 .866-1.5L12.866 3.994Z"></path></svg>)
+        render_default_icon(name, options, for_css)
       end
+    end
+    
+    private
+    def self.render_default_icon(name, options, for_css)
+      height = %Q(height="#{options[:height]}") if options[:height]
+      width = %Q(width="#{options[:width]}") if options[:width]
+      cls = %Q(class="octicon octicon-alert #{options[:class]}")
+      xmlns = %Q(xmlns="http://www.w3.org/2000/svg") if for_css
+      title = %Q(<title>Octicon #{name} is not available</title>)
+      viewbox = %Q(viewBox="0 0 24 24") if options[:width]
+      %Q(<svg #{height} #{width} #{cls} #{viewbox} #{xmlns} version="1.1" aria-hidden="true">#{title}<path d="M13 17.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0Zm-.25-8.25a.75.75 0 0 0-1.5 0v4.5a.75.75 0 0 0 1.5 0v-4.5Z"></path><path d="M9.836 3.244c.963-1.665 3.365-1.665 4.328 0l8.967 15.504c.963 1.667-.24 3.752-2.165 3.752H3.034c-1.926 0-3.128-2.085-2.165-3.752Zm3.03.751a1.002 1.002 0 0 0-1.732 0L2.168 19.499A1.002 1.002 0 0 0 3.034 21h17.932a1.002 1.002 0 0 0 .866-1.5L12.866 3.994Z"></path></svg>)
     end
     
   end # class

--- a/lib/gollum-lib/macro/note.rb
+++ b/lib/gollum-lib/macro/note.rb
@@ -3,16 +3,15 @@ module Gollum
     class Note < Gollum::Macro
       def render(notice, octicon = 'info')
         icon = ""
+        defaults = {width: 24, height: 24, class: 'mr-2'}
         unless octicon.empty?
           begin
-            icon = Octicons::Octicon.new(octicon, {width: 24, height: 24})
+            icon = Gollum::Icon.get_icon(octicon, defaults)
           rescue RuntimeError
-            icon = Octicons::Octicon.new('info', {width: 24, height: 24})
+            icon = Gollum::Icon.get_icon('info', defaults)
           end
-          icon.options[:class] << ' mr-2'
-          icon = icon.to_svg
         end
-        "<div class='flash'>#{icon}#{notice}</div>"
+        "<div class='flash my-2'>#{icon}#{notice}</div>"
       end
     end
   end

--- a/lib/gollum-lib/macro/octicon.rb
+++ b/lib/gollum-lib/macro/octicon.rb
@@ -5,7 +5,7 @@ module Gollum
         parameters = {}
         parameters[:height] = height if height
         parameters[:width]  = width if width
-        "<div>#{Octicons::Octicon.new(symbol, parameters).to_svg}</div>"
+        "<div>#{Gollum::Icon.get_icon(symbol, parameters)}</div>"
       end
     end
   end

--- a/lib/gollum-lib/macro/warn.rb
+++ b/lib/gollum-lib/macro/warn.rb
@@ -2,9 +2,8 @@ module Gollum
   class Macro
     class Warn < Gollum::Macro
       def render(warning)
-        icon = Octicons::Octicon.new('alert', {width: 24, height: 24})
-        icon.options[:class] << ' mr-2'
-        "<div class='flash flash-warn'>#{icon.to_svg}#{warning}</div>"
+        icon = Gollum::Icon.get_icon('alert', {width: 24, height: 24, class: 'mr-2'})
+        "<div class='flash flash-warn my-2'>#{icon}#{warning}</div>"
       end
     end
   end

--- a/lib/gollum-lib/page.rb
+++ b/lib/gollum-lib/page.rb
@@ -368,6 +368,5 @@ module Gollum
       @historical     = false
     end
   end
-  
 
 end

--- a/test/test_macros.rb
+++ b/test/test_macros.rb
@@ -1,6 +1,7 @@
 # ~*~ encoding: utf-8 ~*~
 require File.expand_path('../helper', __FILE__)
 require File.expand_path('../wiki_factory', __FILE__)
+require 'rubygems/commands/install_command'
 
 class Gollum::Macro::ListArgs < Gollum::Macro
   def render(*args)
@@ -171,12 +172,12 @@ context "Macros" do
 
   test "Note macro given a string displays a regular flash message box" do
     @wiki.write_page("NoteMacroPage", :markdown, '<<Note("Did you know Bilbo is a Hobbit?")>>', commit_details)
-    assert_match /<div class=\"flash\"><svg.*class=\"octicon octicon-info mr-2\".*Did you know Bilbo.*/, @wiki.pages[0].formatted_data
+    assert_match /<div class=\"flash my-2\"><svg.*class=\"octicon octicon-info mr-2\".*Did you know Bilbo.*/, @wiki.pages[0].formatted_data
   end
 
   test "Warn macro given a string displays a flash-warning message box" do
     @wiki.write_page("WarnMacroPage", :markdown, '<<Warn("Be careful not to mention hobbits in conversation too much.")>>', commit_details)
-    assert_match /<div class=\"flash flash-warn\"><svg.*class=\"octicon octicon-alert mr-2\".*Be careful.*/, @wiki.pages[0].formatted_data
+    assert_match /<div class=\"flash flash-warn my-2\"><svg.*class=\"octicon octicon-alert mr-2\".*Be careful.*/, @wiki.pages[0].formatted_data
   end
 
   test "Macro errors are reported in place in a flash-error message box" do
@@ -191,8 +192,23 @@ context "Macros" do
 
   test "Note macro renders HTML code" do
     @wiki.write_page("HTMLNoteMacroPage", :markdown, '<<Note("<span>test</span>")>>', commit_details)
-    assert_match /<div class=\"flash\"><svg.*class=\"octicon octicon-info mr-2\".*<span>test<\/span>.*/, @wiki.pages[0].formatted_data
+    assert_match /<div class=\"flash my-2\"><svg.*class=\"octicon octicon-info mr-2\".*<span>test<\/span>.*/, @wiki.pages[0].formatted_data
   end
+
+  test "Macros use fallback icon if Ocitcons gem is not available" do
+    Gollum::Icon.class_variable_set(:@@octicons, false)
+    @wiki.write_page("GollumIconPage", :markdown, '<<Octicon("bell")>>', commit_details)
+    assert_match /<div><svg.*class=\"octicon octicon-alert \".*/, @wiki.pages[0].formatted_data
+    Gollum::Icon.class_variable_set(:@@octicons, true)
+  end
+
+  test "Macro fallback icon respects dimension options" do
+    Gollum::Icon.class_variable_set(:@@octicons, false)
+    @wiki.write_page("GollumIconPage", :markdown, '<<Octicon("bell", 64, 64)>>', commit_details)
+    assert_match /<div><svg height=\"64\" width=\"64\".*class=\"octicon octicon-alert \".*/, @wiki.pages[0].formatted_data
+    Gollum::Icon.class_variable_set(:@@octicons, true)
+  end
+
 
   test "Series macro escapes page names" do
     @wiki.write_page("test-1", :markdown, "test1", commit_details)

--- a/test/test_macros.rb
+++ b/test/test_macros.rb
@@ -1,7 +1,6 @@
 # ~*~ encoding: utf-8 ~*~
 require File.expand_path('../helper', __FILE__)
 require File.expand_path('../wiki_factory', __FILE__)
-require 'rubygems/commands/install_command'
 
 class Gollum::Macro::ListArgs < Gollum::Macro
   def render(*args)


### PR DESCRIPTION
At present, the `octicons` gem is used directly in both `gollum-lib` and `gollum`. This PR is a first step to streamline this use across both gems by way of a `Gollum::Icon` class with a `get_icon` method. Another PR in gollum will follow at a later stage. This PR does two further things:

* It relaxes the constraints on the `octicons` gem version in gollum-lib. This ensures that `gollum-lib` will still have some version of that gem available when `gollum-lib` is used without `gollum`, without getting in the way of upgrading `octicons` at the frontend side  (`gollum`) where the version constraints are more strict.
* It ensures that if a specific octicon is not available, a fallback icon is used.