### PR TITLE
`<<Video ..., auto=true>>` to auto-play inline video (GIF style)

### DIFF
--- a/lib/gollum-lib/macro/video.rb
+++ b/lib/gollum-lib/macro/video.rb
@@ -1,8 +1,10 @@
 module Gollum
   class Macro
     class Video < Gollum::Macro
-      def render (fname)
-        "<video width=\"100%\" height=\"100%\" src=\"#{CGI::escapeHTML(fname)}\" controls=\"true\"> HTML5 video is not supported on this Browser.</video>"
+      def render(fname, auto=false)
+        escaped_fname = CGI.escapeHTML(fname)
+        properties = auto ? "autoplay='true' playsinline='true' muted='true' loop='true'" : "controls='true'"
+        "<video width='100%' height='100%' src='#{escaped_fname}' #{properties}>HTML5 video is not supported on this browser.</video>"
       end
     end
   end

--- a/lib/gollum-lib/sanitization.rb
+++ b/lib/gollum-lib/sanitization.rb
@@ -1,5 +1,5 @@
 ::Loofah::HTML5::SafeList::ACCEPTABLE_PROTOCOLS.add('apt')
-::Loofah::HTML5::SafeList::ALLOWED_ATTRIBUTES.add('controls')
+::Loofah::HTML5::SafeList::ALLOWED_ATTRIBUTES.merge(%w[controls loop muted playsinline autoplay])
 
 module Gollum
   class Sanitization

--- a/test/test_macros.rb
+++ b/test/test_macros.rb
@@ -150,11 +150,27 @@ context "Macros" do
     assert_match(/@xyzzy = Foo@/, @wiki.pages[0].formatted_data)
   end
 
-  test "Video macro given a name of a file displays an html5 video tag" do
+  test "Video macro given a name of a file renders an html5 video tag" do
     file = "/Uploads/foo.mp4"
     @wiki.write_page("VideoTagTest", :markdown, "<<Video(#{file})>>", commit_details)
-    assert_match /<video (.*) src="#{file}"(.*)> (.*)<\/video>/, @wiki.pages[0].formatted_data
+    assert_match /<video (.*) src="#{file}"(.*)>(.*)<\/video>/, @wiki.pages[0].formatted_data
   end 
+
+  test "Video macro auto play mode adds required attributes; removes controls" do
+    # also take the opportunity to check that URL encoding is OK
+    file = "/Uploads/foo .mp4"
+    @wiki.write_page("VideoTagTest", :markdown, "<<Video(#{file}, auto=true)>>", commit_details)
+
+    assert_match /<video (.*)src="\/Uploads\/foo%20.mp4"(.*)>(.*)<\/video>/, @wiki.pages[0].formatted_data
+
+    attributes = ["autoplay", "playsinline", "muted", "loop"]
+
+    attributes.each do |attribute|
+      assert_match /<video(.*)#{attribute}="true"(.*)<\/video>/, @wiki.pages[0].formatted_data
+    end
+
+    assert_not_match /<video(.*)controls="true(.*)<\/video>/, @wiki.pages[0].formatted_data
+  end
 
   test "Audio macro given a name of a file displays an audio tag" do
     file = "/Uploads/foo.mp3"

--- a/test/test_macros.rb
+++ b/test/test_macros.rb
@@ -158,10 +158,10 @@ context "Macros" do
 
   test "Video macro auto play mode adds required attributes; removes controls" do
     # also take the opportunity to check that URL encoding is OK
-    file = "/Uploads/foo .mp4"
+    file = "/Uploads/foo<script>.mp4"
     @wiki.write_page("VideoTagTest", :markdown, "<<Video(#{file}, auto=true)>>", commit_details)
 
-    assert_match /<video (.*)src="\/Uploads\/foo%20.mp4"(.*)>(.*)<\/video>/, @wiki.pages[0].formatted_data
+    assert_match /<video (.*)src="\/Uploads\/foo&lt;script&gt;.mp4"(.*)>(.*)<\/video>/, @wiki.pages[0].formatted_data
 
     attributes = ["autoplay", "playsinline", "muted", "loop"]
 


### PR DESCRIPTION
- Using the `="true"` work-around as in #430.
- The change in `sanitization.rb` further addresses gollum/gollum#1587 by allowing more of the standard video properties.
- Also featured: less escaping, capitalisation fix.