### PR TITLE
Update adapters to support ruby 3.2

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [jruby-9.3.2.0]
+        ruby: [jruby-9.4.0.0]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.7', '3.0', '3.1']
+        ruby: ['2.7', '3.1', '3.2.1']
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2

--- a/Rakefile
+++ b/Rakefile
@@ -189,7 +189,7 @@ end
 desc 'Build changlog'
 task :changelog do
   [latest_changes_file, history_file].each do |f|
-    unless File.exists?(f)
+    unless File.exist?(f)
       puts "#{f} does not exist but is required to build a new release."
       exit!
     end

--- a/gollum-lib.gemspec
+++ b/gollum-lib.gemspec
@@ -3,8 +3,8 @@ require File.join(File.dirname(__FILE__), 'lib', 'gollum-lib', 'version.rb')
 # This file needs to conditionally define the default adapter for MRI and Java, because this is the file that is included from the Gemfile.
 # In addition, the default Java adapter needs to be defined in gollum-lib_java.gemspec beause that file is used to *build* the Java gem.
 if RUBY_PLATFORM == 'java' then
-  default_adapter = ['gollum-rjgit_adapter', '~> 0.6']
+  default_adapter = ['gollum-rjgit_adapter', '~> 1.0']
 else
-  default_adapter = ['gollum-rugged_adapter', '~> 1.0']
+  default_adapter = ['gollum-rugged_adapter', '~> 2.0']
 end
 Gem::Specification.new &specification(Gollum::Lib::VERSION, default_adapter)


### PR DESCRIPTION
Update the adapter dependencies to prepare for a `5.x` release to provide compatibility with ruby 3.2.

Note that this doesn't yet allow gollum to run on 3.2, because there is another dependency (`mustache-sinatra`) with compatibility issues. See https://github.com/gollum/gollum/issues/1928