### PR TITLE
Address XSS issue in TOC filter

### DIFF
--- a/lib/gollum-lib/filter/toc.rb
+++ b/lib/gollum-lib/filter/toc.rb
@@ -157,7 +157,7 @@ class Gollum::Filter::TOC < Gollum::Filter
     end
 
     # % -> %25 so anchors work on Firefox. See issue #475
-    @tail.add_child(%Q{<a href="##{name}">#{header.content}</a>})
+    @tail.add_child(%Q{<a href="##{name}">#{CGI.escapeHTML(header.content)}</a>})
   end
 
   # Increments the number of anchors with the given name

--- a/lib/gollum-lib/wiki.rb
+++ b/lib/gollum-lib/wiki.rb
@@ -152,7 +152,7 @@ module Gollum
       @per_page_uploads     = options.fetch :per_page_uploads, false
       @metadata             = options.fetch :metadata, {}
       @filter_chain         = options.fetch :filter_chain,
-                                            [:YAML, :BibTeX, :PlainText, :CriticMarkup, :TOC, :RemoteCode, :Code, :Macro, :Emoji, :Sanitize, :PlantUML, :Tags, :PandocBib, :Render]
+                                            [:YAML, :BibTeX, :PlainText, :CriticMarkup, :TOC, :Sanitize, :RemoteCode, :Code, :Macro, :Emoji, :PlantUML, :Tags, :PandocBib, :Render]
       @filter_chain.delete(:Emoji) unless options.fetch :emoji, false
       @filter_chain.delete(:PandocBib) unless ::Gollum::MarkupRegisterUtils.using_pandoc?
       @filter_chain.delete(:CriticMarkup) unless options.fetch :critic_markup, false

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -379,6 +379,22 @@ DATA
     assert_html_equal expected, output
   end
 
+  test 'backtick code blocks no xss' do
+    page = 'test_xss'
+    markup = <<EOF
+[[_TOC_]]
+
+```
+<svg><script>alert(1)</script></svg>
+```
+---
+EOF
+    @wiki.write_page(page, :markdown, markup, commit_details)
+    output   = @wiki.page(page).formatted_data
+    puts output.inspect
+    assert_no_match /\<script\>/, output
+  end
+
   test "backtick code blocks must have no more than three space indents" do
     page = 'test_rgx'
     @wiki.write_page(page, :markdown,


### PR DESCRIPTION
An XSS vulnerability in the TOC filter was reported by @6661620a. Thanks for spotting this bug!

### Vulnerablity report by @6661620a

Hi everyone --
it looks like I have discovered a Stored Cross-Site Scripting vulnerability in the markdown parsing feature of Gollum Wiki that could potentially allow an attacker to inject and store malicious scripts, which could later be executed by unsuspecting users opening a wiki page.

**Description**
The vulnerability is triggered when the source code of an svg image that contains a <script> block is placed inside a code block (```) followed by a horizontal line. I just tested this on the latest docker build, installed via `docker pull gollumwiki/gollum:master`

**Steps to Reproduce**
Steps to reproduce the behavior:

1. Create a new markdown file
2. insert the following code and **replace [code block start] and [code block end] with 3 backticks (```)** to start the code block

```
[[_TOC_]]

[code block start]
<svg><script>alert(1)</script></svg>
[code block end]
---

```
3. Save the file
4. Visit the wiki page

**Expected behavior**
No alert box should appear but only the code should be displayed.

**Screenshots**
![image](https://user-images.githubusercontent.com/10408378/227008640-3f6b999a-7c48-4bda-847c-a3c880bcec7a.png)
![image](https://user-images.githubusercontent.com/10408378/227008744-56e5b117-613f-4930-865f-bd724d3466d7.png)


### Solution

This PR  provides a regression test against this vulnerability and resolves it in the most straightforward way, by HTML-escaping the content of the list items in the TOC. We can discuss other options, such as moving the Sanitize filter to before the TOC filter in the filter chain, but that approach broke a bunch of TOC related tests. If the tests for this PR succeed, I will release a bugfix release of gollum-lib, and then we can consider what the best way to address the issue in fact is.