### PR TITLE
Ensure boolean Macro arguments are parsed as boolean. Resolves #441

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [jruby-9.3.2.0]
+        ruby: [jruby-9.4.0.0]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.6', '2.7', '3.0', '3.1']
+        ruby: ['2.7', '3.0', '3.1']
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2

--- a/LATEST_CHANGES.md
+++ b/LATEST_CHANGES.md
@@ -3,3 +3,7 @@
 * Default to local PlantUML server for security. #412. (@manofstick)
 * Allow use of default branch name `main` or `master. Resolves https://github.com/gollum/gollum/issues/1813. (@dometto)
 * Support use of commit notes in Gollum::Committer. (@dometto, @bartkamphorst)
+
+### Bugfixes
+
+* Fix the use of boolean arguments in Macros. #441. (@dometto)

--- a/lib/gollum-lib/filter/macro.rb
+++ b/lib/gollum-lib/filter/macro.rb
@@ -22,13 +22,18 @@ class Gollum::Filter::Macro < Gollum::Filter
       argstr.scan(/,?\s*(#{arg})\s*/) do |arguments|
       	# Stabstabstab
       	argument = arguments.first
-      	
-        if argument =~ /^([a-z0-9_]+)="(.*?)"/
-      		opts[Regexp.last_match[1]] = Regexp.last_match[2]
-			  elsif argument =~ /^"(.*)"$/
-				  args << Regexp.last_match[1].gsub("\\\"", "\"")
-			  else
-				  args << argument
+
+        case argument
+        in /^([a-z0-9_]+)="(.*?)"/
+          opts[Regexp.last_match[1]] = Regexp.last_match[2]
+        in /^"(.*)"$/
+          args << Regexp.last_match[1].gsub("\\\"", "\"")
+        in /\s*false\s*/
+          args << false
+        in /\s*true\s*/
+          args << true
+        else
+          args << argument
         end
       end
 		  

--- a/test/test_macros.rb
+++ b/test/test_macros.rb
@@ -50,6 +50,13 @@ context "Macros" do
     assert_match /<div class="toc"><div class="toc-title">Navigate this directory<\/div><ul><li><a href="\/NavigationMacroPage.md" rel="nofollow">NavigationMacroPage.md<\/a><\/li><li><a href="\/ZZZZ\/A\.md" rel="nofollow">ZZZZ\/A\.md<\/a><\/li><\/ul><\/div>/, @wiki.pages[0].formatted_data
   end
 
+  test "Navigation macro does not show fullpath if last parameter is full_path is set to false" do
+    # This is also a regression test against https://github.com/gollum/gollum-lib/issues/446
+    @wiki.write_page("NavigationMacroPage", :markdown, '<<Navigation("My TOC", "ZZZZ", false)>>', commit_details)
+    @wiki.write_page("ZZZZ/A", :markdown, "content", commit_details)
+    assert_match /<div class="toc"><div class="toc-title">My TOC<\/div><ul><li><a href="\/ZZZZ\/A\.md" rel="nofollow">A\.md<\/a><\/li><\/ul><\/div>/, @wiki.pages[0].formatted_data
+  end
+
   test "Series macro displays series links with and without series prefix" do
     @wiki.write_page("test-series1", :markdown, "<<Series(test)>>", commit_details)
     testseries1 = @wiki.page("test-series1")

--- a/test/test_macros.rb
+++ b/test/test_macros.rb
@@ -50,7 +50,7 @@ context "Macros" do
     assert_match /<div class="toc"><div class="toc-title">Navigate this directory<\/div><ul><li><a href="\/NavigationMacroPage.md" rel="nofollow">NavigationMacroPage.md<\/a><\/li><li><a href="\/ZZZZ\/A\.md" rel="nofollow">ZZZZ\/A\.md<\/a><\/li><\/ul><\/div>/, @wiki.pages[0].formatted_data
   end
 
-  test "Navigation macro does not show fullpath if last parameter is full_path is set to false" do
+  test "Navigation macro does not show full path if parameter full_path is set to false" do
     # This is also a regression test against https://github.com/gollum/gollum-lib/issues/446
     @wiki.write_page("NavigationMacroPage", :markdown, '<<Navigation("My TOC", "ZZZZ", false)>>', commit_details)
     @wiki.write_page("ZZZZ/A", :markdown, "content", commit_details)


### PR DESCRIPTION
See #441. I have rewritten `Macro#extract` to handle `false` and `true` arguments explicitly.