### PR TITLE
Fix absolute path includes from a subdir

### DIFF
--- a/lib/gollum-lib/filter/tags.rb
+++ b/lib/gollum-lib/filter/tags.rb
@@ -120,8 +120,12 @@ class Gollum::Filter::Tags < Gollum::Filter
   def process_include_tag(tag)
     len = INCLUDE_TAG.length
     return html_error('Cannot process include directive: no page name given') if tag.length <= len
-    page_name          = tag[len..-1]
-    resolved_page_name = ::File.join(@markup.dir, page_name)
+    page_path = Pathname.new(tag[len..-1])
+    if page_path.relative?
+      resolved_page_name = (Pathname.new(@markup.dir) + page_path).to_s
+    else
+      resolved_page_name = page_path.cleanpath.to_s
+    end
     if @markup.include_levels > 0
       page = find_page_or_file_from_path(resolved_page_name)
       if page

--- a/lib/gollum-lib/filter/tags.rb
+++ b/lib/gollum-lib/filter/tags.rb
@@ -121,10 +121,10 @@ class Gollum::Filter::Tags < Gollum::Filter
     len = INCLUDE_TAG.length
     return html_error('Cannot process include directive: no page name given') if tag.length <= len
     page_path = Pathname.new(tag[len..-1])
-    if page_path.relative?
-      resolved_page_name = (Pathname.new(@markup.dir) + page_path).to_s
+    resolved_page_name = if page_path.relative?
+       (Pathname.new(@markup.dir) + page_path).cleanpath.to_s
     else
-      resolved_page_name = page_path.cleanpath.to_s
+      page_path.to_s
     end
     if @markup.include_levels > 0
       page = find_page_or_file_from_path(resolved_page_name)

--- a/lib/gollum-lib/filter/tags.rb
+++ b/lib/gollum-lib/filter/tags.rb
@@ -124,7 +124,7 @@ class Gollum::Filter::Tags < Gollum::Filter
     resolved_page_name = if page_path.relative?
        (Pathname.new(@markup.dir) + page_path).cleanpath.to_s
     else
-      page_path.to_s
+      page_path.cleanpath.to_s
     end
     if @markup.include_levels > 0
       page = find_page_or_file_from_path(resolved_page_name)

--- a/lib/gollum-lib/filter/tags.rb
+++ b/lib/gollum-lib/filter/tags.rb
@@ -121,11 +121,8 @@ class Gollum::Filter::Tags < Gollum::Filter
     len = INCLUDE_TAG.length
     return html_error('Cannot process include directive: no page name given') if tag.length <= len
     page_path = Pathname.new(tag[len..-1])
-    resolved_page_name = if page_path.relative?
-       (Pathname.new(@markup.dir) + page_path).cleanpath.to_s
-    else
-      page_path.cleanpath.to_s
-    end
+    resolved_page = page_path.relative? ? (Pathname.new(@markup.dir) + page_path) : page_path
+    resolved_page_name = resolved_page.cleanpath.to_s
     if @markup.include_levels > 0
       page = find_page_or_file_from_path(resolved_page_name)
       if page

--- a/test/test_markup.rb
+++ b/test/test_markup.rb
@@ -578,6 +578,13 @@ EOF
     assert_html_equal("<p>hello<br /></p><p>&lt;java</p><p>script&gt;alert(99);</p>", page1.formatted_data)
   end
 
+  test "include directive with absolute path from subdir" do
+    @wiki.write_page("/subdir/page1", :textile, "hello\n[[include:/a/very/long/path/to/page2]]\n", commit_details)
+    @wiki.write_page("/a/very/long/path/to/page2", :textile, "success", commit_details)
+    page1 = @wiki.page("/subdir/page1")
+    assert_html_equal("<p>hello<br/></p><p>success</p>", page1.formatted_data)
+  end
+
   test "include directive with very long absolute path and relative include" do
     @wiki.write_page("page1", :textile, "hello\n[[include:/a/very/long/path/to/page2]]\n", commit_details)
     @wiki.write_page("/a/very/long/path/to/page2", :textile, "goodbye\n[[include:object]]", commit_details)


### PR DESCRIPTION
Resolves https://github.com/gollum/gollum/issues/1978

As https://github.com/gollum/gollum/issues/1978 explains, include tags with an absolute path currently do not work. The file-to-include is always resolved as the current directory *plus* the path provided in the tag. This does not work when attempting to include an absolute path in a document in a subidr (the resolved file will then be `"/subdir/absolute/path"` instead of `"/absolute/path"`).

This PR addresses the issue by checking the include path in order to determine whether it is absolute or not, and only prepending the current directory path in case it is relative.

Many thanks to @aaakbar for identifying the issue and pinpointing the solution! 