### PR TITLE
Raise error when attempting to make changes to a file modified in the worktree

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 gemspec :name => 'gollum-lib'
 gem 'irb'
+gem 'gollum-rugged_adapter', git: 'https://github.com/dometto/rugged_adapter', branch: 'clean_workdir'
 
 if RUBY_PLATFORM == 'java' then
   group :development do

--- a/lib/gollum-lib.rb
+++ b/lib/gollum-lib.rb
@@ -54,5 +54,6 @@ module Gollum
   class InvalidGitRepositoryError < StandardError; end
   class NoSuchPathError < StandardError; end
   class IllegalDirectoryPath < StandardError; end
+  class WorkdirModifiedError < StandardError; end
 
 end

--- a/lib/gollum-lib/committer.rb
+++ b/lib/gollum-lib/committer.rb
@@ -79,12 +79,15 @@ module Gollum
     # Raises Gollum::DuplicatePageError if a matching filename already exists, unless force_overwrite is explicitly enabled.
     # This way, pages are not inadvertently overwritten.
     #
+    # Even if force_overwrite is enabled, this throws a WorkdirModifiedError if the workdir path contains modifications that are not in the repository.
+    #
     # Returns nothing (modifies the Index in place).
     def add_to_index(path, data, options = {}, force_overwrite = false)
       if tree = index.current_tree
         unless page_path_scheduled_for_deletion?(index.tree, path) || force_overwrite
           raise DuplicatePageError.new(path) if tree / path
         end
+        raise WorkdirModifiedError.new(path) if index.workdir_path_modified?(path)
       end
 
       unless options[:normalize] == false

--- a/lib/gollum-lib/wiki.rb
+++ b/lib/gollum-lib/wiki.rb
@@ -355,7 +355,7 @@ module Gollum
       committer    = multi_commit ? commit[:committer] : Committer.new(self, commit)
 
       if !rename
-        committer.add(page.path, normalize(data))
+        committer.add_to_index(page.path, data, {normalize: true}, true)
       else
         committer.delete(page.path)
         committer.add_to_index(new_path, data)

--- a/test/test_committer.rb
+++ b/test/test_committer.rb
@@ -148,6 +148,20 @@ context "Committer with a writable wiki" do
     assert_equal @wiki.repo.head.commit.note, 'My notes'
   end
 
+  test "raise WorkdirModifiedError when the workdir contains changes" do
+    committer = Gollum::Committer.new(@wiki)
+    path = 'Bilbo-Baggins.md'
+    filepath = File.join(@wiki.path, path)
+
+    f = File.open(filepath, 'w') { |f| f.puts "Workdir no longer clean" }
+    assert_raises Gollum::WorkdirModifiedError do
+      committer.add_to_index(path, 'content', {}, true)
+    end
+
+    File.delete(filepath)
+    assert_equal 'content', committer.add_to_index(path, 'content', {}, true)
+  end
+
   teardown do
     FileUtils.rm_rf(@path)
   end


### PR DESCRIPTION
Relies on https://github.com/gollum/rugged_adapter/pull/64

This begins work on a fix for https://github.com/gollum/gollum/issues/1975.

The `WorkdirModifiedError` is thrown whenever a file in the workdir has modifications, or is new -- and we then attempt to create a commit containing that file (either by updating it, or creating it anew).

Note that this does not take care of all cases in which workdir data might be lost: reverts work via a different logic.