### PR TITLE
Add support for GitLab style plantuml blocks and additional diagram types

### DIFF
--- a/lib/gollum-lib/filter/code.rb
+++ b/lib/gollum-lib/filter/code.rb
@@ -47,8 +47,23 @@ class Gollum::Filter::Code < Gollum::Filter
     end
     
 
+    def replace_plantuml(data)
+      unless data.match(/\s*@start(uml|json|yaml|ebnf|regex|salt|ditaa|gantt|chronology|mindmap|wbs|math|latex|chen)/m)
+        data = "@startuml\n#{data}\n@enduml\n"
+      end
+      data
+    end
+
+    # print the SHA1 ID with the proper indentation
     data.gsub!(/^([ ]{0,3})``` ?([^\r\n]+)?\r?\n(.+?)\r?\n[ ]{0,3}```[ \t]*\r?$/m) do
-      "#{Regexp.last_match[1]}#{cache_codeblock(Regexp.last_match[2].to_s.strip, Regexp.last_match[3], Regexp.last_match[1])}" # print the SHA1 ID with the proper indentation
+      indent = Regexp.last_match[1]
+      lang = Regexp.last_match[2].to_s.strip
+      code = Regexp.last_match[3]
+      if lang.downcase == "plantuml"
+        "#{indent}#{replace_plantuml(code)}"
+      else
+        "#{indent}#{cache_codeblock(lang, code, indent)}"
+      end
     end
     data
   end

--- a/lib/gollum-lib/filter/plantuml.rb
+++ b/lib/gollum-lib/filter/plantuml.rb
@@ -69,7 +69,8 @@ class Gollum::Filter::PlantUML < Gollum::Filter
   # Extract all sequence diagram blocks into the map and replace with
   # placeholders.
   def extract(data)
-    data.gsub(/(@start(uml|json|yaml|salt|mindmap|wbs|math|latex)\r?\n.+?\r?\n@end\2\r?$)/m) do
+    pu_pat = /(@start(uml|json|yaml|ebnf|regex|salt|ditaa|gantt|chronology|mindmap|wbs|math|latex|chen)([ \t\f\v]+[^\r\n]+|[ \t\r\f\v]*)\n.+?\r?\n@end\2\r?$)/m
+    data.gsub(pu_pat) do
       id       = "#{open_pattern}#{Digest::SHA1.hexdigest($1)}#{close_pattern}"
       @map[id] = { :code => $1 }
       id


### PR DESCRIPTION
- Support for [GitLab style ```plantuml blocks](https://github.com/gollum/gollum/issues/1260)
- Extends the diagram types available to include [{ebnf, regex, ditaa, gantt, chronology, chen}](https://plantuml.com/).  

### Examples
- PlantUML tags are used in the same way as before
```
    @startuml
    A <|-- B
    @enduml
```

-  Defaults to `@startuml`
```
    ```plantuml
    A <|-- B
    ```
```

```
    ```plantuml
    