### PR TITLE
Improve performance by supporting repo.lstree with a specific path

### DIFF
--- a/lib/gollum-lib.rb
+++ b/lib/gollum-lib.rb
@@ -23,6 +23,7 @@ require File.expand_path('../gollum-lib/hook', __FILE__)
 require File.expand_path('../gollum-lib/committer', __FILE__)
 require File.expand_path('../gollum-lib/pagination', __FILE__)
 require File.expand_path('../gollum-lib/blob_entry', __FILE__)
+require File.expand_path('../gollum-lib/tree_entry', __FILE__)
 require File.expand_path('../gollum-lib/wiki', __FILE__)
 require File.expand_path('../gollum-lib/redirects', __FILE__)
 require File.expand_path('../gollum-lib/file', __FILE__)
@@ -31,6 +32,7 @@ require File.expand_path('../gollum-lib/macro', __FILE__)
 require File.expand_path('../gollum-lib/markup', __FILE__)
 require File.expand_path('../gollum-lib/markups', __FILE__)
 require File.expand_path('../gollum-lib/sanitization', __FILE__)
+
 require File.expand_path('../gollum-lib/filter', __FILE__)
 
 module Gollum

--- a/lib/gollum-lib/tree_entry.rb
+++ b/lib/gollum-lib/tree_entry.rb
@@ -1,0 +1,16 @@
+# ~*~ encoding: utf-8 ~*~
+module Gollum
+    # Represents a Tree (directory) that can be contained in another Tree.
+    # We do not really care about any information other than the Tree's path and name:
+    # If we want to know a Tree `foo`'s'contents, this can be achieved by e.g. calling wiki.path_list(foo.path)
+    class TreeEntry
+        attr_reader :sha
+        attr_reader :path
+
+        def initialize(sha, path)
+            @sha = sha
+            @path = path
+            @name = ::File.basename(@path)
+        end
+    end
+end

--- a/test/test_wiki.rb
+++ b/test/test_wiki.rb
@@ -48,6 +48,11 @@ context "Wiki" do
     assert_equal commits, @wiki.log(:page_num => 2).map(&:id)
   end
 
+  test "list specific directory in the wiki" do
+    puts @wiki.path_list('Mordor').inspect
+    assert false
+  end
+
   test "list files and pages" do
     contents = @wiki.tree_list
     pages = contents.select {|x| x.is_a?(::Gollum::Page)}


### PR DESCRIPTION
This PR adds support for new adapter features which allow us to call `lstree` for a specific directory in the repo, and non-recursively:

https://github.com/gollum/rugged_adapter/pull/67
https://github.com/gollum/rjgit_adapter/pull/26
Specs: https://github.com/gollum/adapter_specs/pull/19

This will eventually allow us to improve performance of the Overview route, as we'll no longer need to get and loop over the entire contents of the repository.