### PR TITLE
Anon user email at a RFC2606 reserved domain

### DIFF
--- a/lib/gollum-lib/wiki.rb
+++ b/lib/gollum-lib/wiki.rb
@@ -32,7 +32,7 @@ module Gollum
       end
 
       def default_committer_email
-        @default_committer_email || 'anon@anon.com'
+        @default_committer_email || 'anon@anonymous.invalid'
       end
 
       def default_options


### PR DESCRIPTION
The previous value "anon.com" is a real-world domain, unrelated to Gollum (or deployments of Gollum). Use a domain specified as reserved by RFC2606 and so guaranteed not to be in legitimate use elsewhere.

Fixes https://github.com/gollum/gollum/issues/2109.