### PR TITLE
Update test.yaml

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [jruby-9.4.0.0]
+        ruby: [jruby-9.4]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.7', '3.1', '3.2.1']
+        ruby: ['3.1.4', '3.2.1', '3.3']
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2


### PR DESCRIPTION
Drop Ruby 2.7, less strict JRuby 9.4 requirement. Brings test versions in line with gollum/gollum.