### PR TITLE
Fix for copy-to-clipboard button not appearing when Pygments is enabled

### DIFF
--- a/lib/gollum-lib/filter/code.rb
+++ b/lib/gollum-lib/filter/code.rb
@@ -92,7 +92,7 @@ class Gollum::Filter::Code < Gollum::Filter
         lexer = Pygments::Lexer[(lang)] || Pygments::Lexer['text']
 
         # must set startinline to true for php to be highlighted without <?
-        hl_code = lexer.highlight(code, :options => { :encoding => encoding.to_s, :startinline => true })
+        hl_code = lexer.highlight(code, :options => { :encoding => encoding.to_s, :wrapcode => true, :startinline => true })
       else # Rouge
         begin
           # if `lang` was not defined then assume plaintext


### PR DESCRIPTION
When Pygments is enabled for code fences, the copy-to-clipboard buttons do not appear. This is because the Javascript code  for it in Gollum expects the HTML contents of a code fence to be `<pre><code>...</code></pre>`. This is what Rouge produces and what the HTML 5 specification recommends.

By default, Pygments produces a block with `<pre>...</pre>`. So the Javascript code doesn't identify the code fences in the HTML.

When calling the Pygments lexer, the code now sets the HtmlFormatter's '[wrapcode](https://pygments.org/docs/formatters/#HtmlFormatter)' option to true. It makes Pygments produce HTML with `<pre><code>...</code></pre>` and fixes the issue.

The `wrapcode` option is available in Pygments version 2.4 and above only. I'm not sure if that matters for Gollum's use or not. My patch doesn't check for that.