### PR TITLE
Require ostruct since it is not part of default ruby 2.5

### DIFF
--- a/gemspec.rb
+++ b/gemspec.rb
@@ -21,6 +21,7 @@ def specification(version, default_adapter, platform = nil)
     s.extra_rdoc_files = %w(README.md LICENSE)
 
     s.add_dependency *default_adapter
+    s.add_dependency 'ostruct', '~> 0.6'
     s.add_dependency 'rouge', '~> 3.1'
     s.add_dependency 'nokogiri', '~> 1.8'
     s.add_dependency 'loofah', '~> 2.3'


### PR DESCRIPTION
A lot of base libs are moved to gems with Ruby 2.5.0.

```
warning: ostruct is not part of the default gems since Ruby 3.5.0. Install ostruct from RubyGems.
```