### PR TITLE
allow macros to provide javascript that is added to the page

### DIFF
--- a/lib/gollum-lib/filter.rb
+++ b/lib/gollum-lib/filter.rb
@@ -49,6 +49,8 @@ module Gollum
 
     PLACEHOLDER_PATTERN = /%(\S+)%.+=\1=/
 
+    attr_reader :scripts
+
     # Setup the object.  Sets `@markup` to be the instance of Gollum::Markup that
     # is running this filter chain, and sets `@map` to be an empty hash (for use
     # in your extract/process operations).
@@ -58,6 +60,7 @@ module Gollum
       @map    = {}
       @open_pattern = "%#{self.class.to_s.split('::').last}%"
       @close_pattern = "=#{self.class.to_s.split('::').last}="
+      @scripts = Set.new
     end
 
     attr_reader :open_pattern, :close_pattern
@@ -70,6 +73,10 @@ module Gollum
     def process(data)
       raise RuntimeError,
             "#{self.class} has not implemented ##process!"
+    end
+
+    def add_javascript(script)
+      @scripts.add(script) if script
     end
 
     protected

--- a/lib/gollum-lib/filter/macro.rb
+++ b/lib/gollum-lib/filter/macro.rb
@@ -51,7 +51,9 @@ class Gollum::Filter::Macro < Gollum::Filter
 
       data.gsub!(id) do
         begin
-          Gollum::Macro.instance(macro, @markup.wiki, @markup.page).render(*args)
+          macro_instance = Gollum::Macro.instance(macro, @markup.wiki, @markup.page)
+          add_javascript(macro_instance.javascript)
+          macro_instance.render(*args)
         rescue StandardError => e
           %Q(<div class="flash flash-error gollum-macro-error my-2">Macro Error for #{macro}: #{e.message}</div>)
         end

--- a/lib/gollum-lib/macro.rb
+++ b/lib/gollum-lib/macro.rb
@@ -19,7 +19,9 @@ module Gollum
             "#{self.class} does not implement #render.  "+
             "This is a bug in #{self.class}."
     end
-    
+
+    def javascript; end
+
     protected
     def html_error(s)
       "<p class=\"gollum-error\">#{s}</p>"

--- a/lib/gollum-lib/markup.rb
+++ b/lib/gollum-lib/markup.rb
@@ -137,11 +137,17 @@ module Gollum
       yield Nokogiri::HTML::DocumentFragment.parse(data) if block_given?
 
       # Then we process the data through the chain *backwards*
+      scripts = Set.new
       filter_chain.reverse.each do |filter|
         data = filter.process(data)
+        scripts |= filter.scripts
       end
-
-      data
+      output = ''
+      if scripts.any?
+        all_script = scripts.map {|script| script.gsub('<', '\u003c')}.join("\n")
+        output += "<script>#{all_script}</script>"
+      end
+      output + data
     end
 
     # Render the content with Gollum wiki syntax on top of the file's own

--- a/test/test_macros.rb
+++ b/test/test_macros.rb
@@ -6,6 +6,20 @@ class Gollum::Macro::ListArgs < Gollum::Macro
   def render(*args)
     args.map { |a| "@#{a}@" }.join("\n")
   end
+
+  def javascript
+    'alert("</script>")'
+  end
+end
+
+class Gollum::Macro::Javascript < Gollum::Macro
+  def render(*args)
+    ''
+  end
+
+  def javascript
+    'alert("</script>")'
+  end
 end
 
 class Gollum::Macro::ListNamedArgs < Gollum::Macro
@@ -145,11 +159,21 @@ context "Macros" do
     assert_match(/@wombat@/, @wiki.pages[0].formatted_data)
     assert_match(/@funny things@/, @wiki.pages[0].formatted_data)
   end
-  
+
   test "Args parser doesn't overstep its boundaries" do
     @wiki.write_page("MultiMacroPage", :markdown, "<<ListArgs(Foo)>>\n\n<<NonExistentMacro()>>", commit_details)
     assert_match(/@Foo@/, @wiki.pages[0].formatted_data)
     assert_match(/Unknown macro: NonExistentMacro/, @wiki.pages[0].formatted_data)
+  end
+
+  test "Javascript provided by the macro is added to the page" do
+    @wiki.write_page("JavascriptMacroPage", :markdown, "<<Javascript()>>", commit_details)
+    assert_match("<script>alert(\"\\u003c\/script>\")</script>\n", @wiki.pages[0].formatted_data)
+  end
+
+  test "Javascript is not duplicated when the macro is uses multiple times" do
+    @wiki.write_page("JavascriptMacroPage", :markdown, "<<Javascript()>> <<Javascript()>>", commit_details)
+    assert_match("<script>alert(\"\\u003c\/script>\")</script><p> </p>\n", @wiki.pages[0].formatted_data)
   end
 
   test "Args parser handles named args" do


### PR DESCRIPTION
addresses [#2169](/gollum/gollum/issues/#2169)

The change turned out to be more complicated than I thought. I naively assumed that the sanitization of macro output would happen on the macro output. But that's not the case. The whole page is sanitized at the end of processing.

That makes it more complicated and less local to allow macros to provided javascript without being sanitzed.

The solution I choose is not too nice but hopefully acceptable.
A nicer solution would require to change the data passed through the filter chain from a simple string to a more structured and extendable object. That would require to touch all of the existing filters, which is beyond the amount of changes I want to do.

My change allows filters to collect a set of script texts (strings) in an instance variable of the filter and builds a union of scripts when the filters are run (in markup.rb) that is added to the output within script tags.