### PR TITLE
structured global toc macro

### DIFF
--- a/gemspec.rb
+++ b/gemspec.rb
@@ -95,6 +95,7 @@ def specification(version, default_adapter, platform = nil)
     lib/gollum-lib/macro/navigation.rb
     lib/gollum-lib/macro/note.rb
     lib/gollum-lib/macro/series.rb
+    lib/gollum-lib/macro/structured_global_toc.rb
     lib/gollum-lib/macro/video.rb
     lib/gollum-lib/macro/warn.rb
     lib/gollum-lib/markup.rb

--- a/lib/gollum-lib/macro/structured_global_toc.rb
+++ b/lib/gollum-lib/macro/structured_global_toc.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+module Gollum
+  class Macro
+    class StructuredGlobalTOC < Gollum::Macro
+      TocPage = Struct.new(:page, :path) do
+        def initialize(page:, path: nil)
+          super(page, path || page.url_path.split('/'))
+        end
+      end
+
+      def render(title = "Global Table of Contents")
+        @toc_cnt = 0
+        if @wiki.pages.size > 0
+          result = element(:ul) { page_group_html(page_groups) }
+        end
+        element :div, class: 'toc', style: 'cursor: pointer' do
+            element(:div, class: 'toc-title') { CGI::escapeHTML(title) } +
+            result.to_s
+        end
+      end
+
+      def javascript
+        <<~SCRIPT
+          document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.toggle-button').forEach(function(button) {
+              button.addEventListener('click', function() {
+                const targetId = this.dataset.target;
+                const targetSection = document.getElementById(targetId);
+                if (targetSection.attributes['style'].value == 'display:none;') {
+                  targetSection.attributes['style'].value = '';
+                  this.textContent = '▾' + this.textContent.substring(1);
+                } else {
+                  targetSection.attributes['style'].value = 'display:none;';
+                  this.textContent = '▸' + this.textContent.substring(1);
+                }
+              });
+            });
+          });
+        SCRIPT
+      end
+
+      private
+
+      def page_group_html(groups, full_path = [])
+        groups.map do |path, group|
+          if path
+            folder_html(path, group, full_path + [path])
+          else
+            pages_html(group)
+          end
+        end.join('')
+      end
+
+      def folder_html(path, group, full_path)
+        active = within?(full_path)
+        toggle_txt = active ? "&#9662;\u{2002}" : "&#9656;\u{2002}"
+        style = active ? '' : 'display:none;'
+        toc_id = "toc_#{@toc_cnt += 1}"
+        element :li, style: 'list-style-type: none;' do
+          element(:span, class: 'toggle-button',
+                  style: 'margin-left: -1em',
+                  'data-target': toc_id) {
+            toggle_txt + CGI::escapeHTML(capitalize(path))
+          } +
+            element(:ul, id: toc_id, style: style) {
+            page_group_html(group, full_path)
+          }
+        end
+      end
+
+      def pages_html(group)
+        group.map do |p|
+          element :li, style: 'list-style-type: disc;' do
+            element :a, href: prepath + '/' + p.page.escaped_url_path do
+              page_name(p.page)
+            end
+          end
+        end.join
+      end
+
+      def within?(path)
+        active_page.url_path.start_with?(path.join('/'))
+      end
+
+      def page_name(page)
+        name = capitalize(page.name)
+        if name.size > 18
+          element :span, title: CGI::escapeHTML(name) do
+            CGI::escapeHTML(name[0..17]) + "…"
+          end
+        else
+          CGI::escapeHTML(name)
+        end
+      end
+
+      def capitalize(text)
+        text.split(/[\s_]+/).map { |word| word = word[0].upcase + word[1..] }.join(' ')
+      end
+
+      def prepath
+        @prepath ||= @wiki.base_path.sub(/\/$/, '')
+      end
+
+      def page_groups
+        group(@wiki.pages.map { |page| TocPage.new(page: page) })
+      end
+
+      def group(pages, offset=0)
+        groups = pages.group_by { |page| page.path.size > offset + 1 ? page.path[offset] : nil }
+        groups.each do |path, subgroup|
+          next unless subgroup.any? { |page| page.path.size > offset + 1 }
+
+          groups[path] = group(subgroup, offset + 1)
+        end
+        groups.sort_by { |path, _group| path || '' }
+      end
+
+      def element(name, attributes = {})
+        out = '<' + ([name] + attributes.map {|name, value| "#{name}='#{value}'"}).join(' ')
+        if block_given?
+          out += '>'
+          out += yield
+          out += "</#{name}>"
+        else
+          out += '/>'
+        end
+        out
+      end
+    end
+  end
+end

--- a/test/macro/test_structured_global_toc.rb
+++ b/test/macro/test_structured_global_toc.rb
@@ -1,0 +1,101 @@
+require_relative '../helper'
+require_relative '../wiki_factory'
+require 'pry'
+require 'pp'
+
+context 'StructuredGlobalToc' do
+  setup do
+    @wiki, @path, @teardown = WikiFactory.create 'examples/test.git'
+
+    @wiki.write_page('home', :markdown, "home")
+    @wiki.write_page('very_very_long_page_name', :markdown, "home")
+    @wiki.write_page('hier/page', :markdown, "hier page")
+    @wiki.write_page('hier/ar/chy', :markdown, "hierarchy")
+    @wiki.write_page('hier/and/there', :markdown, "hier and there")
+    @wiki.write_page('folder/page', :markdown, "folder page")
+    @wiki.write_page('toc', :markdown, "<<StructuredGlobalTOC()>>")
+
+    @page = @wiki.pages.detect { |page| page.url_path == 'hier/and/there.md' }
+
+    @macro = Gollum::Macro::StructuredGlobalTOC.new(@wiki, @page)
+  end
+
+  teardown do
+    @teardown.call
+  end
+
+  test 'empty wiki' do
+    wiki, _path, teardown = WikiFactory.create 'examples/empty.git'
+    macro = Gollum::Macro::StructuredGlobalTOC.new(wiki, wiki.pages.first)
+    assert_equal("<div class='toc' style='cursor: pointer'>" \
+                 "<div class='toc-title'>Global Table of Contents</div></div>",
+                 macro.render)
+  ensure
+    teardown.call
+  end
+
+  test 'page grouping' do
+    groups = @macro.send(:page_groups)
+    paths = extract_paths(groups)
+    assert_equal({ nil => ["home.md",
+                           "toc.md",
+                           "very_very_long_page_name.md"]}, paths[0])
+    assert_equal({ "folder" => [
+                     { nil => ["folder", "page.md"]}
+                   ] }, paths[1])
+    assert_equal({ "hier" => [
+                     {nil => ["hier", "page.md"]},
+                     {"and" => [{nil=>["hier", "and", "there.md"]}]},
+                     {"ar" => [{nil=>["hier", "ar", "chy.md"]}]}
+                   ] }, paths[2])
+  end
+
+  test 'html generation' do
+    toc_html = @macro.render
+    toc = Nokogiri::HTML toc_html
+
+    top_level = toc.xpath('//div/ul/li')
+    # page entries first
+    assert_equal('Home', top_level[0].xpath('a').text)
+    assert_equal('Toc', top_level[1].xpath('a').text)
+    assert_equal('Very Very Long Pag…', top_level[2].xpath('a').text)
+    assert_equal('Very Very Long Page Name',
+                 top_level[2].xpath('a/span').first['title'])
+
+    # folders then
+    folder = top_level[3].xpath('span').first
+    assert_equal('▸ Folder', folder.text)
+    assert_equal('toggle-button', folder['class'])
+    assert_equal('toc_1', folder['data-target'])
+    content = toc.xpath("//*[@id='toc_1']").first
+    assert_equal('display:none;', content['style'])
+    assert_equal('Page', content.text)
+
+    hier = top_level[4].xpath('span').first
+    assert_equal('▾ Hier', hier.text)
+    assert_equal('toggle-button', hier['class'])
+    assert_equal('toc_2', hier['data-target'])
+
+    content = toc.xpath("//*[@id='toc_2']").first
+    assert_equal('', content['style'])
+    children = content.xpath('*//a | *//span').map {|e| e.text }
+    assert_equal(["Page", "▾ And", "There", "▸ Ar", "Chy"], children)
+  end
+
+  test 'javascript' do
+    javascript = @macro.javascript
+    assert_instance_of(String, javascript)
+    assert_match(%r{^document.addEventListener\('DOMContentLoaded', function\(\)}, javascript)
+  end
+
+  def extract_paths(pages)
+    return pages.map do |a, b|
+      tupple = if a == nil
+                 [a, b.flat_map { |b| b.path }]
+               else
+                 [a, extract_paths(b) ]
+               end
+      Hash[*tupple]
+    end
+  end
+end


### PR DESCRIPTION
Adds a "structured global toc" macro that creates a list of all pages with their folder structure.

Note that the macro does not fully work without #464 (alternatively one can provide the javascript code as an external javascript). Opening and closing folders will not be functional. 