### PR TITLE
Add Ruby version 4.0.2 to CI matrix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['3.2.1', '3.3', '4.0.2']
+        ruby: ['3.2.1', '3.3', '3.6', '4.0.2']
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['3.2.1', '3.3', '3.5.0', '4.0.2']
+        ruby: ['3.2.1', '3.3', '4.0.2']
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['3.2.1', '3.3', '3.5.0']
+        ruby: ['3.2.1', '3.3', '3.5.0', '4.0.2']
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['3.2.1', '3.3', '3.6', '4.0.2']
+        ruby: ['3.2.1', '3.4', '4.0.2']
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2


### PR DESCRIPTION
Ruby 3.5 was failing. It looks like 3.5 in CI was a preview release, and nokogiri didn't work on it. Let's test on 3.4 and 4.